### PR TITLE
feat: add `ListHeaderComponent` & `ListFooterComponent`

### DIFF
--- a/example/app/(tabs)/flashlist.tsx
+++ b/example/app/(tabs)/flashlist.tsx
@@ -32,12 +32,23 @@ export default function HomeScreen() {
         estimatedItemSize={389}
         // initialScrollIndex={500}
         ref={scrollRef}
+        ListHeaderComponent={<View />}
+        ListHeaderComponentStyle={styles.listHeader}
       />
     </View>
   );
 }
 
 const styles = StyleSheet.create({
+  listHeader: {
+    alignSelf: "center",
+    height: 100,
+    width: 100,
+    backgroundColor: "#456AAA",
+    borderRadius: 12,
+    marginHorizontal: 8,
+    marginTop: 8,
+  },
   outerContainer: {
     backgroundColor: "#456",
   },

--- a/example/app/(tabs)/flatlist.tsx
+++ b/example/app/(tabs)/flatlist.tsx
@@ -12,12 +12,23 @@ export default function HomeScreen() {
         renderItem={renderItem}
         keyExtractor={(item) => item.id}
         contentContainerStyle={styles.listContainer}
+        ListHeaderComponent={<View />}
+        ListHeaderComponentStyle={styles.listHeader}
       />
     </View>
   );
 }
 
 const styles = StyleSheet.create({
+  listHeader: {
+    alignSelf: "center",
+    height: 100,
+    width: 100,
+    backgroundColor: "#456AAA",
+    borderRadius: 12,
+    marginHorizontal: 8,
+    marginTop: 8,
+  },
   outerContainer: {
     backgroundColor: "#456",
   },

--- a/example/app/(tabs)/index.tsx
+++ b/example/app/(tabs)/index.tsx
@@ -46,6 +46,8 @@ export default function HomeScreen() {
                 onEndReached={({ distanceFromEnd }) => {
                     console.log('onEndReached', distanceFromEnd);
                 }}
+                ListHeaderComponent={<View />}
+                ListHeaderComponentStyle={styles.listHeader}
 
                 // initialScrollOffset={20000}
                 // initialScrollIndex={500}
@@ -57,6 +59,15 @@ export default function HomeScreen() {
 }
 
 const styles = StyleSheet.create({
+    listHeader: {
+        alignSelf: "center",
+        height: 100,
+        width: 100,
+        backgroundColor: '#456AAA',
+        borderRadius: 12,
+        marginHorizontal: 8,
+        marginTop: 8,
+    },
     outerContainer: {
         backgroundColor: '#456',
         bottom: Platform.OS === 'ios' ? 82 : 0,

--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -3284,9 +3284,9 @@
             }
         },
         "node_modules/@legendapp/list": {
-            "version": "0.1.0",
+            "version": "0.1.1",
             "resolved": "file:legendapp-list.tgz",
-            "integrity": "sha512-6EmO9BZ1wzrJ+4YyPw7DnMZFFhu7JfBUPMHFqEk+0RZV8N7gbiTgp2kH/gmMavcwDE9a+W8gp/egdr+MHwa96Q==",
+            "integrity": "sha512-mGvHT0SQXwaHauKhSj5cnn0+Rrg+lKwQW/7104yPTbvI8rQ1MtxtRL+4+c7+fbUj01VqM4dESKN4J9Qolmw3Ow==",
             "license": "MIT",
             "dependencies": {
                 "@legendapp/state": "^3.0.0-beta.19"

--- a/src/LegendList.tsx
+++ b/src/LegendList.tsx
@@ -47,6 +47,10 @@ export function LegendList<T>(props: LegendListProps<T>) {
         estimatedItemLength,
         onEndReached,
         onViewableRangeChanged,
+        ListHeaderComponent,
+        ListHeaderComponentStyle,
+        ListFooterComponent,
+        ListFooterComponentStyle,
         ...rest
     } = props;
     const refScroller = useRef<ScrollView>(null);
@@ -446,6 +450,9 @@ export function LegendList<T>(props: LegendListProps<T>) {
             {...rest}
             ref={refScroller}
         >
+            {ListHeaderComponent && (
+                <Reactive.View $style={ListHeaderComponentStyle}>{ListHeaderComponent}</Reactive.View>
+            )}
             {/* {supportsEstimationAdjustment && (
                 <Reactive.View
                     $style={() => ({
@@ -477,6 +484,9 @@ export function LegendList<T>(props: LegendListProps<T>) {
                     />
                 ))}
             </Reactive.View>
+            {ListFooterComponent && (
+                <Reactive.View $style={ListFooterComponentStyle}>{ListFooterComponent}</Reactive.View>
+            )}
         </Reactive.ScrollView>
     );
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,5 @@
 import { ComponentProps, ReactNode } from 'react';
-import { ScrollView } from 'react-native';
+import { ScrollView, StyleProp, ViewStyle } from 'react-native';
 
 export type LegendListProps<T> = Omit<ComponentProps<typeof ScrollView>, 'contentOffset'> & {
     data: ArrayLike<any> & T[];
@@ -16,6 +16,10 @@ export type LegendListProps<T> = Omit<ComponentProps<typeof ScrollView>, 'conten
     keyExtractor?: (item: T, index: number) => string;
     renderItem?: (props: LegendListRenderItemInfo<T>) => ReactNode;
     onViewableRangeChanged?: (range: ViewableRange<T>) => void;
+    ListHeaderComponent?: ReactNode;
+    ListHeaderComponentStyle?: StyleProp<ViewStyle> | undefined;
+    ListFooterComponent?: ReactNode;
+    ListFooterComponentStyle?: StyleProp<ViewStyle> | undefined;
     //   TODO:
     //   onViewableItemsChanged?:
     //     | ((info: {


### PR DESCRIPTION
This pull request adds `ListHeaderComponent` and `ListFooterComponent` to `LegendList`.

### List Component Enhancements:

* [`src/LegendList.tsx`](diffhunk://#diff-4accd310f7e3ff78e8fb07802542457bdb5e953f0c895d7d8b2668807c8c1884R50-R53): Added `ListHeaderComponent`, `ListHeaderComponentStyle`, `ListFooterComponent`, and `ListFooterComponentStyle` to the `LegendList` component, and rendered them conditionally. 
* [`src/types.ts`](diffhunk://#diff-c54113cf61ec99691748a3890bfbeb00e10efb3f0a76f03a0fd9ec49072e410aL2-R2): Updated `LegendListProps` type to include `ListHeaderComponent`, `ListHeaderComponentStyle`, `ListFooterComponent`, and `ListFooterComponentStyle` properties.