### PR TITLE
feat: allow ref usage with LegendList

### DIFF
--- a/example/app/(tabs)/index.tsx
+++ b/example/app/(tabs)/index.tsx
@@ -1,6 +1,6 @@
 import { LegendList } from '@legendapp/list';
-import { useState } from 'react';
-import { LogBox, Platform, StyleSheet, View } from 'react-native';
+import { useRef, useState } from 'react';
+import { LogBox, Platform, ScrollView, StyleSheet, TouchableOpacity, View, Text } from 'react-native';
 import { renderItem } from '../renderItem';
 
 LogBox.ignoreLogs(['Open debugger']);
@@ -13,6 +13,8 @@ console.log(`Using ${uiManager}`);
 const ESTIMATED_ITEM_LENGTH = 200;
 
 export default function HomeScreen() {
+    const scrollViewRef = useRef<ScrollView>(null);
+
     const [data, setData] = useState(
         () =>
             Array.from({ length: 500 }, (_, i) => ({
@@ -33,6 +35,7 @@ export default function HomeScreen() {
     return (
         <View style={[StyleSheet.absoluteFill, styles.outerContainer]}>
             <LegendList
+                ref={scrollViewRef}
                 style={[StyleSheet.absoluteFill, styles.scrollContainer]}
                 contentContainerStyle={styles.listContainer}
                 data={data}

--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -3284,9 +3284,9 @@
             }
         },
         "node_modules/@legendapp/list": {
-            "version": "0.1.0",
+            "version": "0.1.1",
             "resolved": "file:legendapp-list.tgz",
-            "integrity": "sha512-6EmO9BZ1wzrJ+4YyPw7DnMZFFhu7JfBUPMHFqEk+0RZV8N7gbiTgp2kH/gmMavcwDE9a+W8gp/egdr+MHwa96Q==",
+            "integrity": "sha512-x6nCDf+oXiZc33gevUV1rdhxcy5FxunEIi+jhBI9qX1717iK8N6QyOMrZsFluHjxvePvHhTk209b7vWEdL3FEg==",
             "license": "MIT",
             "dependencies": {
                 "@legendapp/state": "^3.0.0-beta.19"

--- a/src/LegendList.tsx
+++ b/src/LegendList.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { beginBatch, endBatch } from '@legendapp/state';
 import { enableReactNativeComponents } from '@legendapp/state/config/enableReactNativeComponents';
 import { Reactive, use$, useObservable } from '@legendapp/state/react';
-import { useCallback, useEffect, useMemo, useRef } from 'react';
+import { ForwardedRef, forwardRef, useCallback, useEffect, useMemo, useRef } from 'react';
 import { Dimensions, ScrollView } from 'react-native';
 import { Container } from './Container';
 import type { LegendListProps } from './types';
@@ -28,7 +28,10 @@ interface VisibleRange {
     topPad: number;
 }
 
-export function LegendList<T>(props: LegendListProps<T>) {
+export const LegendList = forwardRef(<T,>(
+    props: LegendListProps<T>,
+    forwardedRef: ForwardedRef<ScrollView>
+) => {
     const {
         data,
         initialScrollIndex,
@@ -49,7 +52,8 @@ export function LegendList<T>(props: LegendListProps<T>) {
         onViewableRangeChanged,
         ...rest
     } = props;
-    const refScroller = useRef<ScrollView>(null);
+    const internalRef = useRef<ScrollView>(null);
+    const refScroller = (forwardedRef || internalRef) as React.MutableRefObject<ScrollView>;
     const containers$ = useObservable<ContainerInfo[]>(() => []);
     const visibleRange$ = useObservable<VisibleRange>(() => ({
         start: 0,
@@ -479,4 +483,4 @@ export function LegendList<T>(props: LegendListProps<T>) {
             </Reactive.View>
         </Reactive.ScrollView>
     );
-}
+});


### PR DESCRIPTION
The main changes involve adding a ref to the `LegendList` component and refactoring the `LegendList` component to use `forwardRef`.

From the way LegendList works, we could imagine this very simple change, allowing ScrollView methods to be used from a ref

Refactoring `LegendList` component:

* Added `ForwardedRef` and `forwardRef` imports in `src/LegendList.tsx`.
* Refactored `LegendList` to use `forwardRef` for better ref handling.