### PR TITLE
fix: Type Inference LegendList

### DIFF
--- a/example/app/(tabs)/index.tsx
+++ b/example/app/(tabs)/index.tsx
@@ -1,7 +1,7 @@
 import { LegendList } from '@legendapp/list';
 import { useRef, useState } from 'react';
 import { LogBox, Platform, ScrollView, StyleSheet, TouchableOpacity, View, Text } from 'react-native';
-import { renderItem } from '../renderItem';
+import { Item, renderItem } from '../renderItem';
 
 LogBox.ignoreLogs(['Open debugger']);
 
@@ -15,7 +15,7 @@ const ESTIMATED_ITEM_LENGTH = 200;
 export default function HomeScreen() {
     const scrollViewRef = useRef<ScrollView>(null);
 
-    const [data, setData] = useState(
+    const [data, setData] = useState<Item[]>(
         () =>
             Array.from({ length: 500 }, (_, i) => ({
                 id: i.toString(),
@@ -40,7 +40,7 @@ export default function HomeScreen() {
                 contentContainerStyle={styles.listContainer}
                 data={data}
                 renderItem={renderItem}
-                keyExtractor={(item: any) => item.id}
+                keyExtractor={(item) => item.id}
                 estimatedItemLength={() => ESTIMATED_ITEM_LENGTH}
                 drawDistance={1000}
                 recycleItems={true}

--- a/example/app/renderItem.tsx
+++ b/example/app/renderItem.tsx
@@ -14,11 +14,11 @@ import {
 } from "react-native";
 import { useEffect, useState } from "react";
 import { RectButton } from "react-native-gesture-handler";
-import type { LegendListRenderItemInfo } from "@/app/(tabs)";
 import Animated, { Easing, LinearTransition } from "react-native-reanimated";
 import Breathe from "@/components/Breathe";
+import { LegendListRenderItemInfo } from "@legendapp/list";
 
-interface Item {
+export interface Item {
   id: string;
 }
 

--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -3285,9 +3285,9 @@
             }
         },
         "node_modules/@legendapp/list": {
-            "version": "0.1.1",
+            "version": "0.1.2",
             "resolved": "file:legendapp-list.tgz",
-            "integrity": "sha512-eL8Xuo8NlIcgmOkmihTeCIVxUS84MTpn9GxsPb5cxe15zkq200jcqILhJACiK7wqUQAly5f1HGL6bpyNAboCkg==",
+            "integrity": "sha512-u0iPgLt4QMGzKRDXghaAG1odS/yTwEqrP61ZkJOs8FlxRuh7Y47kZScOCkn9u1wUDFpWzmjyDa3JKFmo2KD4FA==",
             "license": "MIT",
             "dependencies": {
                 "@legendapp/state": "^3.0.0-beta.19"

--- a/src/LegendList.tsx
+++ b/src/LegendList.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { beginBatch, endBatch } from '@legendapp/state';
 import { enableReactNativeComponents } from '@legendapp/state/config/enableReactNativeComponents';
 import { Reactive, use$, useObservable } from '@legendapp/state/react';
-import { ForwardedRef, forwardRef, useCallback, useEffect, useMemo, useRef } from 'react';
+import { ForwardedRef, forwardRef, ReactElement, useCallback, useEffect, useMemo, useRef } from 'react';
 import { Dimensions, ScrollView } from 'react-native';
 import { Container } from './Container';
 import type { LegendListProps } from './types';
@@ -28,10 +28,12 @@ interface VisibleRange {
     topPad: number;
 }
 
-export const LegendList = forwardRef(<T,>(
+export const LegendList: <T>(
+    props: LegendListProps<T> & { ref?: ForwardedRef<ScrollView> }
+) => ReactElement = forwardRef(function LegendList<T>(
     props: LegendListProps<T>,
     forwardedRef: ForwardedRef<ScrollView>
-) => {
+) {
     const {
         data,
         initialScrollIndex,
@@ -493,4 +495,4 @@ export const LegendList = forwardRef(<T,>(
             )}
         </Reactive.ScrollView>
     );
-});
+}) as <T>(props: LegendListProps<T> & { ref?: ForwardedRef<ScrollView> }) => ReactElement;


### PR DESCRIPTION
# Fix Generic Type Inference in LegendList Component

## Problem
The `LegendList` component was experiencing type inference issues due to incorrect generic type handling in its declaration. This caused TypeScript errors when trying to use the component with specific data types, particularly around the `keyExtractor` prop.

## Solution
Restructured the component's type declaration by moving the generic type assertion to the end of the component definition using an `as` type cast. This maintains proper type inference while allowing the component to work with generic data types as intended.