### PR TITLE
fix: update list components types to match RN and Flashlist

### DIFF
--- a/src/ListComponent.tsx
+++ b/src/ListComponent.tsx
@@ -36,6 +36,16 @@ interface ListComponentProps
     onLayout: (event: LayoutChangeEvent) => void;
 }
 
+const getComponent = (Component: React.ComponentType<any> | React.ReactElement) => {
+    if (React.isValidElement<any>(Component)) {
+        return Component;
+    }
+    if (Component) {
+        return <Component />;
+    }
+    return null;
+};
+
 export const ListComponent = React.memo(function ListComponent({
     style,
     contentContainerStyle,
@@ -88,7 +98,7 @@ export const ListComponent = React.memo(function ListComponent({
         >
             {alignItemsAtEnd && <Reactive.View $style={() => ({ height: paddingTop$.get() })} />}
             {ListHeaderComponent && (
-                <Reactive.View $style={ListHeaderComponentStyle}>{ListHeaderComponent}</Reactive.View>
+                <Reactive.View $style={ListHeaderComponentStyle}>{getComponent(ListHeaderComponent)}</Reactive.View>
             )}
             {/* {supportsEstimationAdjustment && (
                 <Reactive.View
@@ -106,11 +116,11 @@ export const ListComponent = React.memo(function ListComponent({
                 visibleRange$={visibleRange$}
                 recycleItems={recycleItems!}
                 getRenderedItem={getRenderedItem}
-                ItemSeparatorComponent={ItemSeparatorComponent}
+                ItemSeparatorComponent={ItemSeparatorComponent && getComponent(ItemSeparatorComponent)}
                 updateItemLength={updateItemLength}
             />
             {ListFooterComponent && (
-                <Reactive.View $style={ListFooterComponentStyle}>{ListFooterComponent}</Reactive.View>
+                <Reactive.View $style={ListFooterComponentStyle}>{getComponent(ListFooterComponent)}</Reactive.View>
             )}
         </Reactive.ScrollView>
     );

--- a/src/types.ts
+++ b/src/types.ts
@@ -17,11 +17,11 @@ export type LegendListProps<T> = Omit<ComponentProps<typeof ScrollView>, 'conten
     keyExtractor?: (item: T, index: number) => string;
     renderItem?: (props: LegendListRenderItemInfo<T>) => ReactNode;
     onViewableRangeChanged?: (range: ViewableRange<T>) => void;
-    ListHeaderComponent?: ReactNode;
+    ListHeaderComponent?: React.ComponentType<any> | React.ReactElement | null | undefined;
     ListHeaderComponentStyle?: StyleProp<ViewStyle> | undefined;
-    ListFooterComponent?: ReactNode;
+    ListFooterComponent?: React.ComponentType<any> | React.ReactElement | null | undefined;
     ListFooterComponentStyle?: StyleProp<ViewStyle> | undefined;
-    ItemSeparatorComponent?: ReactNode;
+    ItemSeparatorComponent?: React.ComponentType<any>;
     //   TODO:
     //   onViewableItemsChanged?:
     //     | ((info: {


### PR DESCRIPTION
Currently, the list components (ListHeaderComponent, ListFooterComponent, and ItemSeparatorComponent) are typed as ReactNode. However, both React Native and FlashList support passing either a React component or a node.

This PR updates the types to have the same type definitions as React Native and FlashList.