### PR TITLE
Fix handling of the initialScrollIndex in the list with fixed item sizes

### DIFF
--- a/example/app/(tabs)/_layout.tsx
+++ b/example/app/(tabs)/_layout.tsx
@@ -58,6 +58,15 @@ export default function TabLayout() {
           ),
         }}
       />
+      <Tabs.Screen
+        name="more"
+        options={{
+          title: "More",
+          tabBarIcon: ({ color }) => (
+            <IconSymbol size={28} name="list.dash" color={color} />
+          ),
+        }}
+      />
     </Tabs>
   );
 }

--- a/example/app/(tabs)/index.tsx
+++ b/example/app/(tabs)/index.tsx
@@ -42,7 +42,7 @@ export default function HomeScreen() {
                 data={data}
                 renderItem={renderItem}
                 keyExtractor={(item) => item.id}
-                estimatedItemLength={() => ESTIMATED_ITEM_LENGTH}
+                estimatedItemSize={ESTIMATED_ITEM_LENGTH}
                 drawDistance={1000}
                 recycleItems={RECYCLE_ITEMS}
                 // alignItemsAtEnd

--- a/example/app/(tabs)/more.tsx
+++ b/example/app/(tabs)/more.tsx
@@ -1,0 +1,56 @@
+import React from "react";
+import { View, Text, FlatList, StyleSheet } from "react-native";
+import { Link } from "expo-router";
+import { LegendList } from "@legendapp/list";
+import { SafeAreaView } from "react-native-safe-area-context";
+import { ThemedText } from "@/components/ThemedText";
+
+type ListElement = {
+  id: number;
+  title: string;
+  url: "/initial-scroll-index";
+};
+
+const data: ListElement[] = [
+  {
+    id: 1,
+    title: "Initial scroll index precise navigation",
+    url: "/initial-scroll-index",
+  },
+  // Add more items as needed
+];
+
+const ListItem = ({ title, url }: ListElement) => (
+  <Link href={url}>
+    <View style={styles.item}>
+      <ThemedText>{title}</ThemedText>
+    </View>
+  </Link>
+);
+
+const ListElements = () => {
+  return (
+    <SafeAreaView style={styles.container}>
+      <LegendList
+        estimatedItemSize={80}
+        data={data}
+        renderItem={({ item }) => <ListItem {...item} />}
+        keyExtractor={(item) => item.id.toString()}
+      />
+    </SafeAreaView>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  item: {
+    padding: 16,
+    borderBottomColor: "#ccc",
+    borderBottomWidth: 1,
+    width: "100%",
+  },
+});
+
+export default ListElements;

--- a/example/app/initial-scroll-index/index.tsx
+++ b/example/app/initial-scroll-index/index.tsx
@@ -1,0 +1,108 @@
+import { LegendList } from "@legendapp/list";
+import { useLayoutEffect, useRef, useState } from "react";
+import { LogBox, ScrollView, StyleSheet, View, Text } from "react-native";
+import { Item, renderItem } from "./renderFixedItem";
+import { useNavigation } from "expo-router";
+
+const ITEM_HEIGHT = 400;
+const SEPARATOR_HEIGHT = 52;
+const ESTIMATED_ITEM_LENGTH = 200;
+
+type RenderItem = Item & { type: "separator" | "item" };
+
+const RenderMultiItem = ({
+  item,
+  index,
+}: {
+  item: RenderItem;
+  index: number;
+}) => {
+  if (item.type === "separator") {
+    return (
+      <View
+        style={{
+          height: SEPARATOR_HEIGHT,
+          backgroundColor: "red",
+          justifyContent: "center",
+          alignItems: "center",
+        }}
+      >
+        <Text style={{ color: "white" }}>Separator {item.id}</Text>
+      </View>
+    );
+  }
+  return renderItem({ item, index, height: ITEM_HEIGHT });
+};
+
+export default function ScrollIndexDemo() {
+  const scrollViewRef = useRef<ScrollView>(null);
+
+  const [data, setData] = useState<RenderItem[]>(
+    () =>
+      Array.from({ length: 500 }, (_, i) => ({
+        id: i.toString(),
+        type: i % 3 === 0 ? "separator" : "item",
+      })) as any[],
+  );
+
+  const navigation = useNavigation();
+  useLayoutEffect(() => {
+    navigation.setOptions({
+      title: "Initial scroll index",
+    });
+  }, []);
+
+  return (
+    <View style={[StyleSheet.absoluteFill, styles.outerContainer]}>
+      <LegendList
+        ref={scrollViewRef}
+        style={[StyleSheet.absoluteFill, styles.scrollContainer]}
+        contentContainerStyle={styles.listContainer}
+        data={data}
+        renderItem={RenderMultiItem}
+        keyExtractor={(item) => item.id}
+        getEstimatedItemSize={(i, item) =>
+          data[i].type === "separator" ? 52 : 400
+        }
+        estimatedItemSize={ESTIMATED_ITEM_LENGTH}
+        drawDistance={1000}
+        recycleItems={true}
+        // alignItemsAtEnd
+        // maintainScrollAtEnd
+        onEndReached={({ distanceFromEnd }) => {
+          console.log("onEndReached", distanceFromEnd);
+        }}
+        //ListHeaderComponent={<View />}
+        //ListHeaderComponentStyle={styles.listHeader}
+        // initialScrollOffset={20000}
+        initialScrollIndex={50}
+        // inverted
+        // horizontal
+      />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  listHeader: {
+    alignSelf: "center",
+    height: 100,
+    width: 100,
+    backgroundColor: "#456AAA",
+    borderRadius: 12,
+    marginHorizontal: 8,
+    marginTop: 8,
+  },
+  outerContainer: {
+    backgroundColor: "#456",
+  },
+  scrollContainer: {
+    paddingHorizontal: 16,
+    // paddingrVertical: 48,
+  },
+
+  listContainer: {
+    // paddingHorizontal: 16,
+    paddingTop: 48,
+  },
+});

--- a/example/app/initial-scroll-index/renderFixedItem.tsx
+++ b/example/app/initial-scroll-index/renderFixedItem.tsx
@@ -6,17 +6,13 @@ import {
   Text,
   View,
   Image,
-  TouchableOpacity,
   Pressable,
   UIManager,
   Platform,
-  LayoutAnimation,
 } from "react-native";
-import { useEffect, useState } from "react";
+
 import { RectButton } from "react-native-gesture-handler";
-import Animated, { Easing, LinearTransition } from "react-native-reanimated";
-import Breathe from "@/components/Breathe";
-import { LegendListRenderItemInfo } from "@legendapp/list";
+import { loremSentences, randomNames } from "../renderItem";
 
 export interface Item {
   id: string;
@@ -28,51 +24,11 @@ const randomAvatars = Array.from(
   (_, i) => `https://i.pravatar.cc/150?img=${i + 1}`,
 );
 
-export const randomNames = [
-  "Alex Thompson",
-  "Jordan Lee",
-  "Sam Parker",
-  "Taylor Kim",
-  "Morgan Chen",
-  "Riley Zhang",
-  "Casey Williams",
-  "Quinn Anderson",
-  "Blake Martinez",
-  "Avery Rodriguez",
-  "Drew Campbell",
-  "Jamie Foster",
-  "Skylar Patel",
-  "Charlie Wright",
-  "Sage Mitchell",
-  "River Johnson",
-  "Phoenix Garcia",
-  "Jordan Taylor",
-  "Reese Cooper",
-  "Morgan Bailey",
-];
-
 interface ItemCardProps {
   item: Item;
   index: number;
+  height: number;
 }
-
-// Array of lorem ipsum sentences to randomly choose from
-export const loremSentences = [
-  "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
-  "Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.",
-  "Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris.",
-  "Duis aute irure dolor in reprehenderit in voluptate velit esse.",
-  "Excepteur sint occaecat cupidatat non proident, sunt in culpa.",
-  "Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit.",
-  "Neque porro quisquam est, qui dolorem ipsum quia dolor sit amet.",
-  "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
-  "Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.",
-  "Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris.",
-  "Duis aute irure dolor in reprehenderit in voluptate velit esse.",
-  "Excepteur sint occaecat cupidatat non proident, sunt in culpa.",
-  "Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit.",
-  "Neque porro quisquam est, qui dolorem ipsum quia dolor sit amet.",
-];
 
 if (Platform.OS === "android") {
   if (UIManager.setLayoutAnimationEnabledExperimental) {
@@ -115,15 +71,13 @@ const renderRightActions = () => {
   );
 };
 
-export const ItemCard = ({ item }: ItemCardProps) => {
-  const [isExpanded, setIsExpanded] = useState(false);
-
+export const ItemCard = ({ item, height }: ItemCardProps) => {
   const indexForData = item.id.includes("new")
     ? 100 + +item.id.replace("new", "")
     : +item.id;
 
   // Generate 1-5 random sentences
-  const numSentences = ((indexForData * 7919) % loremSentences.length) + 2; // Using prime number 7919 for better distribution
+  const numSentences = 5;
   //   const indexForData =
   //     item.id === "0" ? 0 : item.id === "1" ? 1 : item.id === "new0" ? 2 : 3;
   //   const numSentences =
@@ -139,7 +93,7 @@ export const ItemCard = ({ item }: ItemCardProps) => {
   const timestamp = `${Math.max(1, indexForData % 24)}h ago`;
 
   return (
-    <View style={styles.itemOuterContainer}>
+    <View style={[styles.itemOuterContainer, { height }]}>
       <Swipeable
         renderRightActions={renderRightActions}
         overshootRight={true}
@@ -148,8 +102,6 @@ export const ItemCard = ({ item }: ItemCardProps) => {
         <Pressable
           onPress={() => {
             //   LinearTransition.easing(Easing.ease);
-
-            setIsExpanded(!isExpanded);
           }}
         >
           <View
@@ -184,7 +136,6 @@ export const ItemCard = ({ item }: ItemCardProps) => {
               //   numberOfLines={isExpanded ? undefined : 10}
             >
               {randomText}
-              {isExpanded ? randomText : null}
             </Text>
             <View style={styles.itemFooter}>
               <Text style={styles.footerText}>❤️ 42</Text>
@@ -192,15 +143,14 @@ export const ItemCard = ({ item }: ItemCardProps) => {
               <Text style={styles.footerText}>🔄 8</Text>
             </View>
           </View>
-          <Breathe />
         </Pressable>
       </Swipeable>
     </View>
   );
 };
 
-export const renderItem = ({ item, index }: LegendListRenderItemInfo<Item>) => (
-  <ItemCard item={item} index={index} />
+export const renderItem = ({ item, index, height }: ItemCardProps) => (
+  <ItemCard item={item} index={index} height={height} />
 );
 
 const styles = StyleSheet.create({
@@ -208,7 +158,7 @@ const styles = StyleSheet.create({
     paddingVertical: 8,
     paddingHorizontal: 8,
     // marginTop: 16,
-    maxWidth: 360,
+    //  maxWidth: 360,
   },
   itemContainer: {
     padding: 16,

--- a/example/components/ui/IconSymbol.tsx
+++ b/example/components/ui/IconSymbol.tsx
@@ -13,6 +13,7 @@ const MAPPING = {
   "paperplane.fill": "send",
   "chevron.left.forwardslash.chevron.right": "code",
   "chevron.right": "chevron-right",
+  "list.dash": "more",
 } as Partial<
   Record<
     import("expo-symbols").SymbolViewProps["name"],

--- a/src/LegendList.tsx
+++ b/src/LegendList.tsx
@@ -154,8 +154,9 @@ const LegendListInner: <T>(props: LegendListProps<T> & { ref?: ForwardedRef<Scro
 
         const allocateContainers = useCallback(() => {
             const scrollLength = refState.current!.scrollLength;
+            const averageItemSize = estimatedItemSize ?? getEstimatedItemSize?.(0, data[0]);
             const numContainers =
-                initialNumContainers || Math.ceil((scrollLength + scrollBuffer * 2) / estimatedItemSize) + 4;
+                initialNumContainers || Math.ceil((scrollLength + scrollBuffer * 2) / averageItemSize) + 4;
 
             for (let i = 0; i < numContainers; i++) {
                 set$(ctx, `containerIndex${i}`, -1);

--- a/src/LegendList.tsx
+++ b/src/LegendList.tsx
@@ -33,7 +33,7 @@ const LegendListInner: <T>(props: LegendListProps<T> & { ref?: ForwardedRef<Scro
             horizontal,
             style: styleProp,
             contentContainerStyle: contentContainerStyleProp,
-            initialContainers,
+            initialNumContainers,
             drawDistance,
             recycleItems = true,
             onEndReachedThreshold = 0.5,
@@ -43,7 +43,8 @@ const LegendListInner: <T>(props: LegendListProps<T> & { ref?: ForwardedRef<Scro
             onScroll: onScrollProp,
             keyExtractor,
             renderItem,
-            estimatedItemLength,
+            estimatedItemSize,
+            getEstimatedItemSize,
             onEndReached,
             onViewableRangeChanged,
             ...rest
@@ -95,6 +96,27 @@ const LegendListInner: <T>(props: LegendListProps<T> & { ref?: ForwardedRef<Scro
             return ret + '';
         };
 
+        const getItemLength = (index: number, data: T) => {
+            return getEstimatedItemSize ? getEstimatedItemSize(index, data) : estimatedItemSize;
+        };
+        const calculateInitialOffset = () => {
+            if (initialScrollIndex) {
+                if (getEstimatedItemSize) {
+                    let offset = 0;
+                    for (let i = 0; i < initialScrollIndex; i++) {
+                        offset += getEstimatedItemSize(i, data[i]);
+                    }
+                    return offset;
+                } else if (estimatedItemSize) {
+                    return initialScrollIndex * estimatedItemSize;
+                }
+            }
+            return undefined;
+        };
+
+        const initialContentOffset =
+            initialScrollOffset ?? useMemo(calculateInitialOffset, [initialScrollIndex, estimatedItemSize]);
+
         if (!refState.current) {
             refState.current = {
                 lengths: new Map(),
@@ -112,17 +134,13 @@ const LegendListInner: <T>(props: LegendListProps<T> & { ref?: ForwardedRef<Scro
                 startNoBuffer: 0,
                 endBuffered: 0,
                 endNoBuffer: 0,
-                scroll: 0,
+                scroll: initialContentOffset || 0,
                 topPad: 0,
             };
             refState.current.idsInFirstRender = new Set(data.map((_: any, i: number) => getId(i)));
         }
         refState.current.data = data;
         set$(ctx, `numItems`, data.length);
-
-        const initialContentOffset =
-            initialScrollOffset ??
-            (initialScrollIndex ? initialScrollIndex * estimatedItemLength(initialScrollIndex) : undefined);
 
         const setTotalLength = (length: number) => {
             set$(ctx, `totalLength`, length);
@@ -137,7 +155,7 @@ const LegendListInner: <T>(props: LegendListProps<T> & { ref?: ForwardedRef<Scro
         const allocateContainers = useCallback(() => {
             const scrollLength = refState.current!.scrollLength;
             const numContainers =
-                initialContainers || Math.ceil((scrollLength + scrollBuffer * 2) / estimatedItemLength(0)) + 4;
+                initialNumContainers || Math.ceil((scrollLength + scrollBuffer * 2) / estimatedItemSize) + 4;
 
             for (let i = 0; i < numContainers; i++) {
                 set$(ctx, `containerIndex${i}`, -1);
@@ -190,7 +208,7 @@ const LegendListInner: <T>(props: LegendListProps<T> & { ref?: ForwardedRef<Scro
             // TODO: This could be optimized to not start at 0, to go backwards from previous start position
             for (let i = 0; i < data!.length; i++) {
                 const id = getId(i)!;
-                const length = lengths.get(id) ?? estimatedItemLength(i);
+                const length = lengths.get(id) ?? getItemLength(i, data[i]);
 
                 if (positions.get(id) !== top) {
                     positions.set(id, top);
@@ -333,8 +351,7 @@ const LegendListInner: <T>(props: LegendListProps<T> & { ref?: ForwardedRef<Scro
             let totalLength = 0;
             for (let i = 0; i < data.length; i++) {
                 const id = getId(i);
-
-                totalLength += lengths.get(id) ?? estimatedItemLength(i);
+                totalLength += lengths.get(id) ?? getItemLength(i, data[i]);
             }
             setTotalLength(totalLength);
         }, []);
@@ -373,7 +390,8 @@ const LegendListInner: <T>(props: LegendListProps<T> & { ref?: ForwardedRef<Scro
             const lengths = refState.current?.lengths!;
             const id = getId(index);
             const wasInFirstRender = refState.current?.idsInFirstRender.has(id);
-            const prevLength = lengths.get(id) || (wasInFirstRender ? estimatedItemLength(index) : 0);
+
+            const prevLength = lengths.get(id) || (wasInFirstRender ? getItemLength(index, data[index]) : 0);
             // let scrollNeedsAdjust = 0;
 
             if (!prevLength || prevLength !== length) {
@@ -442,7 +460,18 @@ const LegendListInner: <T>(props: LegendListProps<T> & { ref?: ForwardedRef<Scro
         }, []);
 
         const handleScroll = useCallback(
-            (event: { nativeEvent: { contentOffset: { x: number; y: number } } }, fromSelf?: boolean) => {
+            (
+                event: {
+                    nativeEvent: NativeScrollEvent;
+                },
+                fromSelf?: boolean,
+            ) => {
+                // in some cases when we set ScrollView contentOffset prop, there comes event from with 0 height and width
+                // this causes blank list display, looks to be Paper implementation problem
+                // let's filter out such events
+                if (event.nativeEvent?.contentSize?.height === 0 && event.nativeEvent.contentSize?.width === 0) {
+                    return;
+                }
                 refState.current!.hasScrolled = true;
                 const newScroll = event.nativeEvent.contentOffset[horizontal ? 'x' : 'y'];
                 // Update the scroll position to use in checks
@@ -460,19 +489,6 @@ const LegendListInner: <T>(props: LegendListProps<T> & { ref?: ForwardedRef<Scro
             [],
         );
 
-        useEffect(() => {
-            if (initialContentOffset) {
-                const offset = horizontal ? { x: initialContentOffset, y: 0 } : { x: 0, y: initialContentOffset };
-                handleScroll(
-                    {
-                        nativeEvent: { contentOffset: offset },
-                    },
-                    /*fromSelf*/ true,
-                );
-                calculateItemsInView();
-            }
-        }, []);
-
         return (
             <ListComponent
                 {...rest}
@@ -487,6 +503,7 @@ const LegendListInner: <T>(props: LegendListProps<T> & { ref?: ForwardedRef<Scro
                 onLayout={onLayout}
                 recycleItems={recycleItems}
                 alignItemsAtEnd={alignItemsAtEnd}
+                estimatedItemSize={estimatedItemSize}
             />
         );
     },

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,13 +6,18 @@ export type LegendListProps<T> = Omit<ComponentProps<typeof ScrollView>, 'conten
     initialScrollOffset?: number;
     initialScrollIndex?: number;
     drawDistance?: number;
-    initialContainers?: number;
+    initialNumContainers?: number;
     recycleItems?: boolean;
     onEndReachedThreshold?: number | null | undefined;
     maintainScrollAtEnd?: boolean;
     maintainScrollAtEndThreshold?: number;
     alignItemsAtEnd?: boolean;
-    estimatedItemLength: (index: number) => number;
+    // in most cases providing a constant value for item size enough
+    estimatedItemSize: number;
+    // in case you have distinct item sizes, you can provide a function to get the size of an item
+    // use instead of FlatList's getItemLayout or FlashList overrideItemLayout
+    // if you want to have accurate initialScrollOffset, you should provide this function
+    getEstimatedItemSize?: (index: number, item: T) => number;
     onEndReached?: ((info: { distanceFromEnd: number }) => void) | null | undefined;
     keyExtractor?: (item: T, index: number) => string;
     renderItem?: (props: LegendListRenderItemInfo<T>) => ReactNode;


### PR DESCRIPTION
This PR fixes adds possibility to use precise initialScrollIndex values. To have more precise calculation LegendList API was needed to be changed.
```
    estimatedItemSize: number;
    getEstimatedItemSize?: (index: number, item: T) => number;
```
Some additional changes were made:

- Added more tab with showcase different list options(good for the demo, I can delete it if needed).
- Removed effect to call handleScroll when initialScrollIndex is specified. initialContentOffset is passed directly to refState.current.scroll. This eliminates unneeded useEffect, and animation jerk upon initialisation.
- Fix issue with empty list on the Paper architecture.

Related issue: https://github.com/LegendApp/legend-list/issues/13