### PR TITLE
[Example app] Freeze inactive tabs of the tab navigator

### DIFF
--- a/example/app/(tabs)/_layout.tsx
+++ b/example/app/(tabs)/_layout.tsx
@@ -16,6 +16,7 @@ export default function TabLayout() {
       screenOptions={{
         tabBarActiveTintColor: Colors[colorScheme ?? "light"].tint,
         headerShown: false,
+        lazy: true,
         tabBarButton: HapticTab,
         tabBarBackground: TabBarBackground,
         tabBarStyle: Platform.select({

--- a/example/app/_layout.tsx
+++ b/example/app/_layout.tsx
@@ -9,6 +9,7 @@ import * as SplashScreen from "expo-splash-screen";
 import { StatusBar } from "expo-status-bar";
 import { useEffect } from "react";
 import "react-native-reanimated";
+import { enableFreeze } from "react-native-screens";
 
 import { useColorScheme } from "@/hooks/useColorScheme";
 import { GestureHandlerRootView } from "react-native-gesture-handler";
@@ -17,6 +18,7 @@ import { configureReanimatedLogger } from "react-native-reanimated";
 
 // Prevent the splash screen from auto-hiding before asset loading is complete.
 SplashScreen.preventAutoHideAsync();
+enableFreeze(); // freeze inactive tabs in the tabbar, to improve benchmarking accuracy
 
 configureReanimatedLogger({
   level: ReanimatedLogLevel.warn,


### PR DESCRIPTION
I have found out, that after opening some other tabs(FlatList), "Legend List" tab's fps drops significantly. It looks like other tabs are still rendering in background. This PR enables freezing of inactive tabs, which should result in more accurate benchmarks.