### PR TITLE
fix: internal state types

### DIFF
--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -11,6 +11,7 @@
             "license": "0BSD",
             "dependencies": {
                 "@expo/vector-icons": "^14.0.2",
+                "@legendapp/list": "^0.3.6",
                 "@legendapp/motion": "^2.4.0",
                 "@legendapp/state": "^3.0.0-beta.19",
                 "@react-navigation/bottom-tabs": "^7.0.0",
@@ -3281,6 +3282,16 @@
             "dependencies": {
                 "@jridgewell/resolve-uri": "^3.1.0",
                 "@jridgewell/sourcemap-codec": "^1.4.14"
+            }
+        },
+        "node_modules/@legendapp/list": {
+            "version": "0.3.6",
+            "resolved": "https://registry.npmjs.org/@legendapp/list/-/list-0.3.6.tgz",
+            "integrity": "sha512-gRll/uehFzXOtmsaFaVy9/mbETzZkUvhBjLjEt7qfTYFGaz8hhHRF5rLeo9H0kex3KkErVW8j3BJbjjTXbGq7w==",
+            "license": "MIT",
+            "peerDependencies": {
+                "react": "*",
+                "react-native": "*"
             }
         },
         "node_modules/@legendapp/motion": {

--- a/example/package.json
+++ b/example/package.json
@@ -21,6 +21,7 @@
     },
     "dependencies": {
         "@expo/vector-icons": "^14.0.2",
+        "@legendapp/list": "^0.3.6",
         "@legendapp/motion": "^2.4.0",
         "@legendapp/state": "^3.0.0-beta.19",
         "@react-navigation/bottom-tabs": "^7.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@legendapp/list",
-    "version": "0.3.1",
+    "version": "0.3.6",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@legendapp/list",
-            "version": "0.3.1",
+            "version": "0.3.6",
             "license": "MIT",
             "devDependencies": {
                 "@biomejs/biome": "^1.9.4",

--- a/src/LegendList.tsx
+++ b/src/LegendList.tsx
@@ -123,7 +123,7 @@ const LegendListInner: <T>(props: LegendListProps<T> & { ref?: ForwardedRef<Lege
                 isEndReached: false,
                 isAtBottom: false,
                 data: data,
-                idsInFirstRender: undefined as any,
+                idsInFirstRender: null,
                 hasScrolled: false,
                 scrollLength: Dimensions.get('window')[horizontal ? 'width' : 'height'],
                 startBuffered: 0,
@@ -133,7 +133,7 @@ const LegendListInner: <T>(props: LegendListProps<T> & { ref?: ForwardedRef<Lege
                 scroll: initialContentOffset || 0,
                 totalSize: 0,
                 timeouts: new Set(),
-                viewabilityConfigCallbackPairs: undefined as any,
+                viewabilityConfigCallbackPairs: null,
             };
             refState.current.idsInFirstRender = new Set(data.map((_: any, i: number) => getId(i)));
         }
@@ -455,7 +455,7 @@ const LegendListInner: <T>(props: LegendListProps<T> & { ref?: ForwardedRef<Lege
             }
             const sizes = refState.current?.sizes!;
             const id = getId(index);
-            const wasInFirstRender = refState.current?.idsInFirstRender.has(id);
+            const wasInFirstRender = refState.current?.idsInFirstRender?.has(id);
 
             const prevSize = sizes.get(id) || (wasInFirstRender ? getItemSize(index, data[index]) : 0);
             // let scrollNeedsAdjust = 0;

--- a/src/types.ts
+++ b/src/types.ts
@@ -45,7 +45,7 @@ export interface InternalState {
     isEndReached: boolean;
     isAtBottom: boolean;
     data: any[];
-    idsInFirstRender: Set<string>;
+    idsInFirstRender: Set<string> | null;
     hasScrolled: boolean;
     scrollLength: number;
     startBuffered: number;
@@ -55,7 +55,7 @@ export interface InternalState {
     scroll: number;
     totalSize: number;
     timeouts: Set<number>;
-    viewabilityConfigCallbackPairs: ViewabilityConfigCallbackPairs;
+    viewabilityConfigCallbackPairs: ViewabilityConfigCallbackPairs | null;
 }
 
 export interface ViewableRange<T> {

--- a/src/viewability.ts
+++ b/src/viewability.ts
@@ -43,12 +43,13 @@ export function setupViewability(props: LegendListProps<any>) {
 export function updateViewableItems(
     state: InternalState,
     ctx: StateContext,
-    viewabilityConfigCallbackPairs: ViewabilityConfigCallbackPair[],
+    viewabilityConfigCallbackPairs: ViewabilityConfigCallbackPair[] | null,
     getId: (index: number) => string,
     scrollSize: number,
     start: number,
     end: number,
 ) {
+    if (!viewabilityConfigCallbackPairs) return;
     for (const viewabilityConfigCallbackPair of viewabilityConfigCallbackPairs) {
         const viewabilityState = mapViewabilityConfigCallbackPairs.get(viewabilityConfigCallbackPair)!;
         viewabilityState.start = start;


### PR DESCRIPTION
Just a PR that fixes internal types in particular `viewabilityConfigCallbackPairs`, which is optional