### PR TITLE
fix: total scroll height calculation issue

### DIFF
--- a/src/LegendList.tsx
+++ b/src/LegendList.tsx
@@ -467,6 +467,18 @@ const LegendListInner: <T>(props: LegendListProps<T> & { ref?: ForwardedRef<Lege
         //     }
         // };
 
+        const calcTotalSizes = () => {
+             // Set an initial total height based on what we know
+             const sizes = refState.current!.sizes!;
+             let totalSize = 0;
+             for (let i = 0; i < data.length; i++) {
+                 const id = getId(i);
+                 totalSize += sizes.get(id) ?? getItemSize(i, data[i]);
+             }
+             addTotalSize(totalSize);
+             console.log({totalSize})
+        }
+
         useInit(() => {
             refState.current!.viewabilityConfigCallbackPairs = setupViewability(props);
 
@@ -484,16 +496,11 @@ const LegendListInner: <T>(props: LegendListProps<T> & { ref?: ForwardedRef<Lege
             set$(ctx, "numContainers", numContainers);
 
             calculateItemsInView();
-
-            // Set an initial total height based on what we know
-            const sizes = refState.current!.sizes!;
-            let totalSize = 0;
-            for (let i = 0; i < data.length; i++) {
-                const id = getId(i);
-                totalSize += sizes.get(id) ?? getItemSize(i, data[i]);
-            }
-            addTotalSize(totalSize);
+            calcTotalSizes();
+           
         });
+
+
 
         const checkAtBottom = () => {
             const { scrollLength, scroll } = refState.current!;
@@ -531,6 +538,7 @@ const LegendListInner: <T>(props: LegendListProps<T> & { ref?: ForwardedRef<Lege
 
             calculateItemsInView();
             checkAtBottom();
+            calcTotalSizes();
         }, [data]);
 
         const updateItemSize = useCallback((index: number, size: number) => {

--- a/src/LegendList.tsx
+++ b/src/LegendList.tsx
@@ -476,7 +476,6 @@ const LegendListInner: <T>(props: LegendListProps<T> & { ref?: ForwardedRef<Lege
                  totalSize += sizes.get(id) ?? getItemSize(i, data[i]);
              }
              addTotalSize(totalSize);
-             console.log({totalSize})
         }
 
         useInit(() => {


### PR DESCRIPTION
Scroll is impossible when initial data height is 0 and data length changes later. It happens because scroll height is calculated only at init.
```
export default function HomeScreen() {
    const listRef = useRef<LegendListRef>(null);

    const [data, setData] = useState<Item[]>([]
      
    );
    useEffect(() => {
        setTimeout(() => {
            setData(sample);
        }, 1000);
    },[])
```
https://github.com/user-attachments/assets/d75425dd-fd54-4d3e-b99a-e992636142d1

