### PR TITLE
Revert total size fix

### DIFF
--- a/src/LegendList.tsx
+++ b/src/LegendList.tsx
@@ -470,17 +470,6 @@ const LegendListInner: <T>(props: LegendListProps<T> & { ref?: ForwardedRef<Lege
         //     }
         // };
 
-        const calcTotalSizes = () => {
-             // Set an initial total height based on what we know
-             const sizes = refState.current!.sizes!;
-             let totalSize = 0;
-             for (let i = 0; i < data.length; i++) {
-                 const id = getId(i);
-                 totalSize += sizes.get(id) ?? getItemSize(i, data[i]);
-             }
-             addTotalSize(totalSize);
-        }
-
         useInit(() => {
             refState.current!.viewabilityConfigCallbackPairs = setupViewability(props);
 
@@ -498,11 +487,16 @@ const LegendListInner: <T>(props: LegendListProps<T> & { ref?: ForwardedRef<Lege
             set$(ctx, "numContainers", numContainers);
 
             calculateItemsInView();
-            calcTotalSizes();
-           
+
+            // Set an initial total height based on what we know
+            const sizes = refState.current!.sizes!;
+            let totalSize = 0;
+            for (let i = 0; i < data.length; i++) {
+                const id = getId(i);
+                totalSize += sizes.get(id) ?? getItemSize(i, data[i]);
+            }
+            addTotalSize(totalSize);
         });
-
-
 
         const checkAtBottom = () => {
             const { scrollLength, scroll } = refState.current!;
@@ -556,7 +550,6 @@ const LegendListInner: <T>(props: LegendListProps<T> & { ref?: ForwardedRef<Lege
             calculateItemsInView();
             checkAtBottom();
             checkAtTop();
-            calcTotalSizes();
         }, [data]);
 
         const updateItemSize = useCallback((index: number, size: number) => {


### PR DESCRIPTION
As testing with https://github.com/LegendApp/legend-list/pull/37 showed, this leads to permanent growth of the list size. I need to think of better solution for the recalculation of list size when data is changed. 
For now we need to revert https://github.com/LegendApp/legend-list/pull/33

https://github.com/user-attachments/assets/9b29a705-37f3-451e-ae56-3c9de94f2343

