### PR TITLE
fix: (example) display menu items on android

### DIFF
--- a/example/app/(tabs)/index.tsx
+++ b/example/app/(tabs)/index.tsx
@@ -1,7 +1,7 @@
 import { ThemedText } from "@/components/ThemedText";
 import { LegendList } from "@legendapp/list";
 import { Link, type LinkProps } from "expo-router";
-import { StyleSheet, View } from "react-native";
+import { Pressable, StyleSheet, View } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 
 type ListElement = {
@@ -43,11 +43,13 @@ const data: ListElement[] = [
 const RightIcon = () => <ThemedText type="subtitle">›</ThemedText>;
 
 const ListItem = ({ title, url }: ListElement) => (
-    <Link href={url}>
-        <View style={styles.item}>
-            <ThemedText>{title}</ThemedText>
-            <RightIcon />
-        </View>
+    <Link href={url} asChild>
+        <Pressable>
+            <View style={styles.item}>
+                <ThemedText>{title}</ThemedText>
+                <RightIcon />
+            </View>
+        </Pressable>
     </Link>
 );
 


### PR DESCRIPTION
Fixes display of the main tab list on Android:
![Screenshot_20241217-081330](https://github.com/user-attachments/assets/9188fe61-d38a-4ad9-96f8-d1be6450f5bc)
