### PR TITLE
fix: Improve scroll velocity handling, add timer to reset scroll velocity

### DIFF
--- a/src/LegendList.tsx
+++ b/src/LegendList.tsx
@@ -900,7 +900,6 @@ const LegendListInner: <T>(props: LegendListProps<T> & { ref?: ForwardedRef<Lege
                 }
 
                 state.scrollTimer = setTimeout(() => {
-                    console.log("Resetting velocity",   state.scrollVelocity);
                     state.scrollVelocity = 0;
                 },500);
 
@@ -919,7 +918,6 @@ const LegendListInner: <T>(props: LegendListProps<T> & { ref?: ForwardedRef<Lege
                 state.scrollPrevTime = state.scrollTime;
                 state.scroll = newScroll;
                 state.scrollTime = currentTime;
-                console.log("Setting velocity", velocity, state.scrollHistory);
                 state.scrollVelocity = velocity;
                 // Pass velocity to calculateItemsInView
                 handleScrollDebounced(velocity);

--- a/src/LegendList.tsx
+++ b/src/LegendList.tsx
@@ -884,12 +884,25 @@ const LegendListInner: <T>(props: LegendListProps<T> & { ref?: ForwardedRef<Lege
                 const currentTime = performance.now();
                 const newScroll = event.nativeEvent.contentOffset[horizontal ? "x" : "y"];
 
-                // Update scroll history
-                state.scrollHistory.push({ scroll: newScroll, time: currentTime });
+                // don't add to the history, if it's initial scroll event
+                // otherwise invalid velocity will be calculated
+                if (!(state.scrollHistory.length === 0 && newScroll === initialContentOffset)) {
+                    // Update scroll history
+                    state.scrollHistory.push({ scroll: newScroll, time: currentTime });
+                }
                 // Keep only last 5 entries
                 if (state.scrollHistory.length > 5) {
                     state.scrollHistory.shift();
                 }
+
+                if (state.scrollTimer !== undefined) {
+                    clearTimeout(state.scrollTimer);
+                }
+
+                state.scrollTimer = setTimeout(() => {
+                    console.log("Resetting velocity",   state.scrollVelocity);
+                    state.scrollVelocity = 0;
+                },500);
 
                 // Calculate average velocity from history
                 let velocity = 0;
@@ -906,6 +919,7 @@ const LegendListInner: <T>(props: LegendListProps<T> & { ref?: ForwardedRef<Lege
                 state.scrollPrevTime = state.scrollTime;
                 state.scroll = newScroll;
                 state.scrollTime = currentTime;
+                console.log("Setting velocity", velocity, state.scrollHistory);
                 state.scrollVelocity = velocity;
                 // Pass velocity to calculateItemsInView
                 handleScrollDebounced(velocity);

--- a/src/types.ts
+++ b/src/types.ts
@@ -76,6 +76,7 @@ export interface InternalState {
     viewabilityConfigCallbackPairs: ViewabilityConfigCallbackPairs | undefined;
     renderItem: (props: LegendListRenderItemProps<any>) => ReactNode;
     scrollHistory: Array<{ scroll: number; time: number }>;
+    scrollTimer: number | undefined;
 }
 
 export interface ViewableRange<T> {

--- a/src/types.ts
+++ b/src/types.ts
@@ -76,7 +76,7 @@ export interface InternalState {
     viewabilityConfigCallbackPairs: ViewabilityConfigCallbackPairs | undefined;
     renderItem: (props: LegendListRenderItemProps<any>) => ReactNode;
     scrollHistory: Array<{ scroll: number; time: number }>;
-    scrollTimer: number | undefined;
+    scrollTimer: Timer | undefined;
 }
 
 export interface ViewableRange<T> {


### PR DESCRIPTION
This PR adds timer to reset scroll velocity, when there was no scroll event for 500ms. It also prevents initial scroll to record velocity when using initial scroll index