### PR TITLE
fix: trigger viewability event on scrolling to first item

### DIFF
--- a/src/LegendList.tsx
+++ b/src/LegendList.tsx
@@ -450,9 +450,9 @@ const LegendListInner: <T>(props: LegendListProps<T> & { ref?: ForwardedRef<Lege
 
             // Precompute the scroll that will be needed for the range to change
             // so it can be skipped if not needed
-            const nextTop = Math.ceil(startBuffered ? positions.get(startBufferedId!)! + scrollBuffer : 0);
+            const nextTop = Math.ceil(startBuffered !== null ? positions.get(startBufferedId!)! + scrollBuffer : 0);
             const nextBottom = Math.floor(
-                endBuffered ? (positions.get(getId(endBuffered! + 1))! || 0) - scrollLength - scrollBuffer : 0,
+                endBuffered !== null ? (positions.get(getId(endBuffered! + 1))! || 0) - scrollLength - scrollBuffer : 0,
             );
             if (state.enableScrollForNextCalculateItemsInView) {
                 state.scrollForNextCalculateItemsInView =


### PR DESCRIPTION
Thanks for awesome list library! We were trying it out in our new app. It is working well so far. Noticed that scrolling to initial item does not trigger `onViewableItemsChanged` event (check below video). 

Quickly checked and found it is [returning](https://github.com/LegendApp/legend-list/blob/baf7a205031ffd5bd0c68e749fbf9d628aff64f7/src/LegendList.tsx#L328) early. I did not dig the entire logic but I think we meant to do explicit `null` checks here, because the value remains `0` and does not update. This change fixes it.

https://github.com/user-attachments/assets/dd514784-0710-4483-9ef3-d6e7fd9d9d2d

