### PR TITLE
Set native props

### DIFF
--- a/example/app/(tabs)/index.tsx
+++ b/example/app/(tabs)/index.tsx
@@ -55,6 +55,10 @@ const data: ListElement[] = [
         title: "Extra data",
         url: "/extra-data",
     },
+    {
+        title: "Countries List",
+        url: "/countries",
+    },
     // Add more items as needed
 ].map(
     (v, i) =>

--- a/example/app/(tabs)/index.tsx
+++ b/example/app/(tabs)/index.tsx
@@ -85,9 +85,9 @@ const ListElements = () => {
                 data={data}
                 renderItem={({ item }) => <ListItem {...item} />}
                 keyExtractor={(item) => item.id.toString()}
-                onItemSizeChanged={(info) => {
-                    console.log("item size changed", info);
-                }}
+                // onItemSizeChanged={(info) => {
+                //     console.log("item size changed", info);
+                // }}
             />
         </SafeAreaView>
     );

--- a/example/app/countries/index.tsx
+++ b/example/app/countries/index.tsx
@@ -1,0 +1,168 @@
+import { LegendList } from "@legendapp/list";
+import { type TCountryCode, countries, getEmojiFlag } from "countries-list";
+import { useMemo, useState } from "react";
+import { Pressable, StatusBar, StyleSheet, Text, TextInput, View } from "react-native";
+import { SafeAreaProvider, SafeAreaView } from "react-native-safe-area-context";
+
+export const unstable_settings = {
+    initialRouteName: "index",
+};
+
+export const createTitle = () => "Countries";
+
+type Country = {
+    id: string;
+    name: string;
+    flag: string;
+};
+
+// Convert countries object to array and add an id
+const DATA: Country[] = Object.entries(countries)
+    .map(([code, country]) => ({
+        id: code,
+        name: country.name,
+        flag: getEmojiFlag(code as TCountryCode),
+    }))
+    .sort((a, b) => a.name.localeCompare(b.name));
+
+type ItemProps = {
+    item: Country;
+    onPress: () => void;
+    isSelected: boolean;
+};
+
+const Item = ({ item, onPress, isSelected }: ItemProps) => (
+    <Pressable
+        onPress={onPress}
+        style={({ pressed }) => [styles.item, isSelected && styles.selectedItem, pressed && styles.pressedItem]}
+    >
+        <View style={styles.flagContainer}>
+            <Text style={styles.flag}>{item.flag}</Text>
+        </View>
+        <View style={styles.contentContainer}>
+            <Text style={[styles.title, isSelected && styles.selectedText]}>
+                {item.name}
+                <Text style={styles.countryCode}> ({item.id})</Text>
+            </Text>
+        </View>
+    </Pressable>
+);
+
+const App = () => {
+    const [selectedId, setSelectedId] = useState<string>();
+    const [searchQuery, setSearchQuery] = useState("");
+
+    const filteredData = useMemo(() => {
+        const query = searchQuery.toLowerCase();
+        return DATA.filter(
+            (country) => country.name.toLowerCase().includes(query) || country.id.toLowerCase().includes(query),
+        );
+    }, [searchQuery]);
+
+    const renderItem = ({ item }: { item: Country }) => {
+        const isSelected = item.id === selectedId;
+        return <Item item={item} onPress={() => setSelectedId(item.id)} isSelected={isSelected} />;
+    };
+
+    return (
+        <SafeAreaProvider>
+            <SafeAreaView style={styles.container}>
+                <View style={styles.searchContainer}>
+                    <TextInput
+                        style={styles.searchInput}
+                        placeholder="Search country or code..."
+                        value={searchQuery}
+                        onChangeText={setSearchQuery}
+                        clearButtonMode="while-editing"
+                        autoCapitalize="none"
+                        autoCorrect={false}
+                    />
+                </View>
+                <LegendList
+                    data={filteredData}
+                    renderItem={renderItem}
+                    keyExtractor={(item) => item.id}
+                    extraData={selectedId}
+                    estimatedItemSize={70}
+                />
+            </SafeAreaView>
+        </SafeAreaProvider>
+    );
+};
+
+export default App;
+
+const styles = StyleSheet.create({
+    container: {
+        flex: 1,
+        marginTop: StatusBar.currentHeight || 0,
+        backgroundColor: "#f5f5f5",
+    },
+    searchContainer: {
+        padding: 8,
+        backgroundColor: "#fff",
+        borderBottomWidth: 1,
+        borderBottomColor: "#e0e0e0",
+    },
+    searchInput: {
+        height: 40,
+        backgroundColor: "#f5f5f5",
+        borderRadius: 8,
+        paddingHorizontal: 12,
+        fontSize: 16,
+    },
+    item: {
+        paddingHorizontal: 16,
+        paddingVertical: 6,
+        flexDirection: "row",
+        alignItems: "center",
+        backgroundColor: "#fff",
+        borderRadius: 12,
+        shadowColor: "#000",
+        shadowOffset: {
+            width: 0,
+            height: 2,
+        },
+        shadowOpacity: 0.1,
+        shadowRadius: 3,
+        elevation: 3,
+    },
+    selectedItem: {
+        backgroundColor: "#e3f2fd",
+        borderColor: "#1976d2",
+        borderWidth: 1,
+    },
+    pressedItem: {
+        backgroundColor: "#f0f0f0",
+    },
+    flagContainer: {
+        marginRight: 16,
+        width: 40,
+        height: 40,
+        borderRadius: 20,
+        backgroundColor: "#f8f9fa",
+        alignItems: "center",
+        justifyContent: "center",
+    },
+    flag: {
+        fontSize: 28,
+    },
+    contentContainer: {
+        flex: 1,
+        justifyContent: "center",
+    },
+    title: {
+        fontSize: 16,
+        color: "#333",
+        fontWeight: "500",
+    },
+    selectedText: {
+        color: "#1976d2",
+        fontWeight: "600",
+    },
+    countryCode: {
+        fontSize: 14,
+        color: "#666",
+        fontWeight: "400",
+    },
+});

--- a/example/bun.lock
+++ b/example/bun.lock
@@ -1,5 +1,5 @@
 {
-  "lockfileVersion": 0,
+  "lockfileVersion": 1,
   "workspaces": {
     "": {
       "dependencies": {
@@ -10,6 +10,7 @@
         "@react-navigation/native": "^7.0.14",
         "@shopify/flash-list": "1.7.1",
         "babel-plugin-react-compiler": "^19.0.0-beta-df7b47d-20241124",
+        "countries-list": "^3.1.1",
         "expo": "~52.0.25",
         "expo-blur": "~14.0.2",
         "expo-constants": "~17.0.4",
@@ -856,6 +857,8 @@
     "core-util-is": ["core-util-is@1.0.3", "", {}, ""],
 
     "cosmiconfig": ["cosmiconfig@9.0.0", "", { "dependencies": { "env-paths": "^2.2.1", "import-fresh": "^3.3.0", "js-yaml": "^4.1.0", "parse-json": "^5.2.0" }, "peerDependencies": { "typescript": ">=4.9.5" } }, ""],
+
+    "countries-list": ["countries-list@3.1.1", "", {}, "sha512-nPklKJ5qtmY5MdBKw1NiBAoyx5Sa7p2yPpljZyQ7gyCN1m+eMFs9I6CT37Mxt8zvR5L3VzD3DJBE4WQzX3WF4A=="],
 
     "create-jest": ["create-jest@29.7.0", "", { "dependencies": { "@jest/types": "^29.6.3", "chalk": "^4.0.0", "exit": "^0.1.2", "graceful-fs": "^4.2.9", "jest-config": "^29.7.0", "jest-util": "^29.7.0", "prompts": "^2.0.1" }, "bin": "bin/create-jest.js" }, ""],
 

--- a/example/package.json
+++ b/example/package.json
@@ -22,6 +22,7 @@
         "@react-navigation/native": "^7.0.14",
         "@shopify/flash-list": "1.7.1",
         "babel-plugin-react-compiler": "^19.0.0-beta-df7b47d-20241124",
+        "countries-list": "^3.1.1",
         "expo": "~52.0.25",
         "expo-blur": "~14.0.2",
         "expo-constants": "~17.0.4",

--- a/src/Container.tsx
+++ b/src/Container.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useRef, useState } from "react";
+import React, { useLayoutEffect, useMemo, useRef, useState } from "react";
 import {
     type DimensionValue,
     type LayoutChangeEvent,
@@ -78,9 +78,9 @@ export const Container = ({
             const cur = refLastRender.current!;
             if (currentItemKey === cur.itemKey) {
                 if (Platform.OS !== "web" && !horizontal && measured) {
-                ref.current?.setNativeProps({
-                    style: { opacity: 1, top: newPos.relativeCoordinate },
-                });
+                    ref.current?.setNativeProps({
+                        style: { opacity: 1, top: newPos.relativeCoordinate },
+                    });
                 } else {
                     setRender((prev) => prev + 1);
                 }
@@ -101,6 +101,20 @@ export const Container = ({
             // set$(ctx, "otherAxisSize", Math.max(otherAxisSize, peek$(ctx, "otherAxisSize") || 0));
         }
     };
+
+    useLayoutEffect(() => {
+        if (itemKey) {
+            // @ts-expect-error unstable_getBoundingClientRect is unstable and only on Fabric
+            const measured = ref.current?.unstable_getBoundingClientRect?.();
+            if (measured) {
+                const size = Math.floor(measured[horizontal ? "width" : "height"] * 8) / 8;
+
+                if (size) {
+                    updateItemSize(id, itemKey, size);
+                }
+            }
+        }
+    }, [itemKey]);
 
     const contentFragment = (
         <React.Fragment key={recycleItems ? undefined : itemKey}>

--- a/src/Container.tsx
+++ b/src/Container.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useRef, useState } from "react";
+import React, { useMemo, useRef } from "react";
 import {
     type DimensionValue,
     type LayoutChangeEvent,
@@ -31,9 +31,8 @@ export const Container = ({
 }) => {
     const ctx = useStateContext();
     const maintainVisibleContentPosition = use$<boolean>("maintainVisibleContentPosition");
-    const [position, setPosition] = useState(
-        () => peek$<AnchoredPosition>(ctx, `containerPosition${id}`) || ANCHORED_POSITION_OUT_OF_VIEW,
-    );
+    const position = peek$<AnchoredPosition>(ctx, `containerPosition${id}`) ?? ANCHORED_POSITION_OUT_OF_VIEW;
+
     const column = use$<number>(`containerColumn${id}`) || 0;
     const numColumns = use$<number>("numColumns");
 
@@ -78,8 +77,6 @@ export const Container = ({
                 ref.current?.setNativeProps({
                     style: { opacity: 1, top: newPos.relativeCoordinate },
                 });
-            } else {
-                setPosition(newPos);
             }
         });
     }, []);

--- a/src/Container.tsx
+++ b/src/Container.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useRef } from "react";
+import React, { useMemo, useRef, useState } from "react";
 import {
     type DimensionValue,
     type LayoutChangeEvent,
@@ -32,6 +32,7 @@ export const Container = ({
     const ctx = useStateContext();
     const maintainVisibleContentPosition = use$<boolean>("maintainVisibleContentPosition");
     const position = peek$<AnchoredPosition>(ctx, `containerPosition${id}`) ?? ANCHORED_POSITION_OUT_OF_VIEW;
+    const [_, setRender] = useState(0);
 
     const column = use$<number>(`containerColumn${id}`) || 0;
     const numColumns = use$<number>("numColumns");
@@ -71,12 +72,18 @@ export const Container = ({
 
     useMemo(() => {
         listen$<AnchoredPosition>(ctx, `containerPosition${id}`, (newPos) => {
-            const currentItemKey = peek$(ctx, `containerItemKey${id}`);
+            const currentItemKey = peek$<string>(ctx, `containerItemKey${id}`);
+            const measured = peek$<number>(ctx, "containersDidLayout");
+
             const cur = refLastRender.current!;
-            if (Platform.OS !== "web" && currentItemKey === cur.itemKey && !horizontal) {
+            if (currentItemKey === cur.itemKey) {
+                if (Platform.OS !== "web" && !horizontal && measured) {
                 ref.current?.setNativeProps({
                     style: { opacity: 1, top: newPos.relativeCoordinate },
                 });
+                } else {
+                    setRender((prev) => prev + 1);
+                }
             }
         });
     }, []);

--- a/src/LegendList.tsx
+++ b/src/LegendList.tsx
@@ -614,6 +614,7 @@ const LegendListInner: <T>(props: LegendListProps<T> & { ref?: ForwardedRef<Lege
                 for (const containerId of layoutsPending) {
                     set$(ctx, `containerDidLayout${containerId}`, true);
                 }
+                set$(ctx, "containersDidLayout", true);
                 layoutsPending.clear();
             }
 

--- a/src/state.tsx
+++ b/src/state.tsx
@@ -26,8 +26,9 @@ export type ListenerType =
     | "stylePaddingTop"
     | "scrollAdjust"
     | "headerSize"
-    | "footerSize" 
+    | "footerSize"
     | "maintainVisibleContentPosition"
+    | "containersDidLayout";
 // | "otherAxisSize";
 
 export interface StateContext {


### PR DESCRIPTION
I think this should improve performance when items resize or don't match the estimate. It uses setNativeProps to update the position when the item key has not changed, so it would skip the render and do less work. If itemKey has changed, it will get re-rendered and peek the latest position, so we don't need to use$ that. And since we're not rendering when only position changes, I think we can remove the useMemo around getRenderedItem as now any re-render should re-render the item?

I tried this approach with setting positions using Animated and Reanimated as well. They seemed actually a bit slower than the setNativeProps method. I've tried a lot of different ways to skip that re-render caused by position changing, and this is the best way I can find. This was also an attempt to remove the delay of updating the position after an item size changes, but it didn't successfully solve that, so I think that can only be solved with a native component.

This may likely be better solved by the experiments into a native auto layout view, but I wanted to get as far as we can with pure JS.

On my slow android test phone the performance seems marginally better, but not as much as I'd hoped. I'm curious if it seems any different for you @michbil?