### PR TITLE
fix:Improve scrolling window size

### DIFF
--- a/example/app/cards-flashlist/index.tsx
+++ b/example/app/cards-flashlist/index.tsx
@@ -45,7 +45,7 @@ export default function HomeScreen() {
                 keyExtractor={(item) => item.id}
                 contentContainerStyle={styles.listContainer}
                 estimatedItemSize={ESTIMATED_ITEM_LENGTH}
-                drawDistance={DRAW_DISTANCE / 2} // FlashList seems to multiply the drawDistance internally so this makes it about even
+                drawDistance={DRAW_DISTANCE/2} // FlashList seems to multiply the drawDistance internally so this makes it about even
                 // initialScrollIndex={500}
                 ref={scrollRef}
                 ListHeaderComponent={<View />}
@@ -93,8 +93,8 @@ const styles = StyleSheet.create({
         // borderBottomColor: "#ccc",
     },
     listContainer: {
-        paddingHorizontal: 16,
-        paddingTop: 48,
+        //paddingHorizontal: 16,
+        //paddingTop: 48,
     },
     itemTitle: {
         fontSize: 18,

--- a/example/app/cards-renderItem.tsx
+++ b/example/app/cards-renderItem.tsx
@@ -119,7 +119,7 @@ export const ItemCard = ({
     const refSwipeable = useRef<SwipeableMethods>();
 
     // A useState that resets when the item is recycled
-    const [isExpanded, setIsExpanded] = useRecyclingState ? useRecyclingState(() => false) : useState(() => false);
+    const [isExpanded, setIsExpanded] = useState(() => false);
 
     const swipeableState = useRef(false);
 

--- a/src/LegendList.tsx
+++ b/src/LegendList.tsx
@@ -339,7 +339,8 @@ const LegendListInner: <T>(props: LegendListProps<T> & { ref?: ForwardedRef<Lege
             if (scrollExtra > 8) {
                 scrollBufferTop = 0;
                 scrollBufferBottom = scrollBuffer + scrollExtra;
-            } else {
+            } 
+            if (scrollExtra < -8) {
                 scrollBufferTop = scrollBuffer - scrollExtra;
                 scrollBufferBottom = 0;
             }
@@ -478,7 +479,7 @@ const LegendListInner: <T>(props: LegendListProps<T> & { ref?: ForwardedRef<Lege
             const nextBottom = Math.floor(
                 endBuffered !== null ? (positions.get(getId(endBuffered! + 1))! || 0) - scrollLength - scrollBuffer : 0,
             );
-            if (false) {
+            if (state.enableScrollForNextCalculateItemsInView) {
                 state.scrollForNextCalculateItemsInView =
                     nextTop >= 0 && nextBottom >= 0
                         ? {

--- a/src/LegendList.tsx
+++ b/src/LegendList.tsx
@@ -214,7 +214,6 @@ const LegendListInner: <T>(props: LegendListProps<T> & { ref?: ForwardedRef<Lege
                     isAboveAnchor = true;
                 }
             }
-            const prev = state.totalSize;
             if (key === null) {
                 state.totalSize = add;
                 state.totalSizeBelowAnchor = totalSizeBelowAnchor;
@@ -331,7 +330,21 @@ const LegendListInner: <T>(props: LegendListProps<T> & { ref?: ForwardedRef<Lege
             const topPad = (peek$<number>(ctx, "stylePaddingTop") || 0) + (peek$<number>(ctx, "headerSize") || 0);
             const previousScrollAdjust = scrollAdjustHandler.getAppliedAdjust();
             const scrollExtra = Math.max(-16, Math.min(16, speed)) * 16;
-            const scroll = scrollState - previousScrollAdjust - topPad - scrollExtra;
+            const scroll = scrollState - previousScrollAdjust - topPad;
+
+            let scrollBufferTop = scrollBuffer;
+            let scrollBufferBottom = scrollBuffer;
+
+            
+            if (scrollExtra > 8) {
+                scrollBufferTop = 0;
+                scrollBufferBottom = scrollBuffer + scrollExtra;
+            } else {
+                scrollBufferTop = scrollBuffer - scrollExtra;
+                scrollBufferBottom = 0;
+            }
+
+            //console.log(scrollExtra,scrollBufferTop,scrollBufferBottom)
 
             // Check precomputed scroll range to see if we can skip this check
             if (state.scrollForNextCalculateItemsInView) {
@@ -428,7 +441,7 @@ const LegendListInner: <T>(props: LegendListProps<T> & { ref?: ForwardedRef<Lege
                 if (startNoBuffer === null && top + size > scroll) {
                     startNoBuffer = i;
                 }
-                if (startBuffered === null && top + size > scroll - scrollBuffer) {
+                if (startBuffered === null && top + size > scroll - scrollBufferTop) {
                     startBuffered = i;
                     startBufferedId = id;
                 }
@@ -436,7 +449,7 @@ const LegendListInner: <T>(props: LegendListProps<T> & { ref?: ForwardedRef<Lege
                     if (top <= scrollBottom) {
                         endNoBuffer = i;
                     }
-                    if (top <= scrollBottom + scrollBuffer) {
+                    if (top <= scrollBottom + scrollBufferBottom) {
                         endBuffered = i;
                     } else {
                         break;
@@ -465,7 +478,7 @@ const LegendListInner: <T>(props: LegendListProps<T> & { ref?: ForwardedRef<Lege
             const nextBottom = Math.floor(
                 endBuffered !== null ? (positions.get(getId(endBuffered! + 1))! || 0) - scrollLength - scrollBuffer : 0,
             );
-            if (state.enableScrollForNextCalculateItemsInView) {
+            if (false) {
                 state.scrollForNextCalculateItemsInView =
                     nextTop >= 0 && nextBottom >= 0
                         ? {


### PR DESCRIPTION
During scroll we are spreading draw distance evenly to the top and to the bottom. But during fast scroll we are actually rendering invisible region oposite to the scroll direction. scrollExtra value mitigates the issue, but it doesn't really help with big draw distances. 
