### PR TITLE
fix: Bring back old measurement method unstable_getBoundingClientRect

### DIFF
--- a/src/Container.tsx
+++ b/src/Container.tsx
@@ -80,13 +80,14 @@ export const Container = ({
     if (isNewArchitecture) {
         useLayoutEffect(() => {
             if (itemKey) {
-                let size: number | undefined = undefined;
-                ref.current?.measure?.((x, y, width, height) => {
-                    size = Math.floor(horizontal ? width : height * 8) / 8;
-                });
+                // @ts-expect-error unstable_getBoundingClientRect is unstable and only on Fabric
+                const measured = ref.current?.unstable_getBoundingClientRect?.();
+                if (measured) {
+                    const size = Math.floor(measured[horizontal ? "width" : "height"] * 8) / 8;
 
-                if (size) {
-                    updateItemSize(id, itemKey, size);
+                    if (size) {
+                        updateItemSize(id, itemKey, size);
+                    }
                 }
             }
         }, [itemKey]);


### PR DESCRIPTION
measure() api was not working properly