### PR TITLE
fix: getScrollableNode access even when component is not mounted yet

### DIFF
--- a/src/LegendList.tsx
+++ b/src/LegendList.tsx
@@ -1153,9 +1153,9 @@ const LegendListInner: <T>(props: LegendListProps<T> & { ref?: ForwardedRef<Lege
                 };
                 return {
                     getNativeScrollRef: () => refScroller.current!,
-                    getScrollableNode: refScroller.current!.getScrollableNode,
-                    getScrollResponder: refScroller.current!.getScrollResponder,
-                    flashScrollIndicators: refScroller.current!.flashScrollIndicators,
+                    getScrollableNode: () => refScroller.current!.getScrollableNode(),
+                    getScrollResponder: () => refScroller.current!.getScrollResponder(),
+                    flashScrollIndicators: () => refScroller.current!.flashScrollIndicators(),
                     scrollToIndex,
                     scrollToOffset: ({ offset, animated }) => {
                         const offsetObj = horizontal ? { x: offset, y: 0 } : { x: 0, y: offset };
@@ -1167,7 +1167,7 @@ const LegendListInner: <T>(props: LegendListProps<T> & { ref?: ForwardedRef<Lege
                             scrollToIndex({ index, animated });
                         }
                     },
-                    scrollToEnd: refScroller.current!.scrollToEnd,
+                    scrollToEnd: () => refScroller.current!.scrollToEnd(),
                 };
             },
             [],


### PR DESCRIPTION
Some [APIs](https://github.com/react-navigation/react-navigation/blob/bddcc44ab0e0ad5630f7ee0feb69496412a00217/packages/native/src/useScrollToTop.tsx#L98) access functions like  `getScrollableNode` in an event, which in some edge cases gets triggered even if the ref is not initialised (ideally this should not happen, will need a PR in react navigation to add `null` check). However, to keep the feature parity with `FlatList` i think below change is still helpful. So this PR adds a change that is identical to `FlatList`'s [implementation](https://github.com/facebook/react-native/blob/b45851aecf9e22c6cbd3fc80bf5fa097a34d3d03/packages/react-native/Libraries/Lists/FlatList.js#L394).