### PR TITLE
fix: Add undefined check for anchorElement in maintainVisibleContentPosition logic

### DIFF
--- a/src/LegendList.tsx
+++ b/src/LegendList.tsx
@@ -31,12 +31,12 @@ import { ANCHORED_POSITION_OUT_OF_VIEW, POSITION_OUT_OF_VIEW } from "./constants
 import { StateProvider, peek$, set$, useStateContext } from "./state";
 import type {
     AnchoredPosition,
+    InternalState, LegendListProps,
     LegendListRecyclingState,
     LegendListRef,
     ViewabilityAmountCallback,
     ViewabilityCallback,
 } from "./types";
-import type { InternalState, LegendListProps } from "./types";
 import { useCombinedRef } from "./useCombinedRef";
 import { useInit } from "./useInit";
 import { setupViewability, updateViewableItems } from "./viewability";
@@ -241,7 +241,7 @@ const LegendListInner: <T>(props: LegendListProps<T> & { ref?: ForwardedRef<Lege
             const totalSize = state.totalSize;
             let resultSize = totalSize;
 
-            if (maintainVisibleContentPosition) {
+            if (maintainVisibleContentPosition && anchorElement !== undefined) {
                 const newAdjust = anchorElement!.coordinate - state.totalSizeBelowAnchor;
                 applyAdjustValue = -newAdjust;
                 state.belowAnchorElementPositions = buildElementPositionsBelowAnchor();

--- a/src/LegendList.tsx
+++ b/src/LegendList.tsx
@@ -218,7 +218,7 @@ const LegendListInner: <T>(props: LegendListProps<T> & { ref?: ForwardedRef<Lege
 
         const addTotalSize = useCallback((key: string | null, add: number, totalSizeBelowAnchor: number) => {
             const state = refState.current!;
-            const { scrollLength, indexByKey, anchorElement } = state;
+            const { indexByKey, anchorElement } = state;
             const index = key === null ? 0 : indexByKey.get(key)!;
             let isAboveAnchor = false;
             if (maintainVisibleContentPosition) {
@@ -236,20 +236,18 @@ const LegendListInner: <T>(props: LegendListProps<T> & { ref?: ForwardedRef<Lege
                 }
             }
 
-            let applyAdjustValue = undefined;
-
-            const totalSize = state.totalSize;
-            let resultSize = totalSize;
+            let applyAdjustValue;
+            let resultSize = state.totalSize;
 
             if (maintainVisibleContentPosition && anchorElement !== undefined) {
-                const newAdjust = anchorElement!.coordinate - state.totalSizeBelowAnchor;
+                const newAdjust = anchorElement.coordinate - state.totalSizeBelowAnchor;
                 applyAdjustValue = -newAdjust;
                 state.belowAnchorElementPositions = buildElementPositionsBelowAnchor();
                 state.rowHeights.clear();
 
                 if (applyAdjustValue !== undefined) {
                     resultSize -= applyAdjustValue;
-                    refState.current!.scrollAdjustHandler.requestAdjust(applyAdjustValue, (diff) => {
+                    refState.current!.scrollAdjustHandler.requestAdjust(applyAdjustValue, (diff: number) => {
                         // event state.scroll will contain invalid value, until next handleScroll
                         // apply adjustment
                         state.scroll -= diff;


### PR DESCRIPTION
## Problem
When using maintainVisibleContentPosition, the code was not properly checking if anchorElement was undefined, which could potentially cause runtime errors.

```
Warning: TypeError: Cannot read property 'coordinate' of undefined
```

## Solution
Added an explicit undefined check for anchorElement before accessing its properties to ensure safer code execution.

## Changes
- Added undefined check condition `anchorElement !== undefined` in the maintainVisibleContentPosition logic
- This prevents potential runtime errors when anchorElement is undefined

---

### fyi
Version I use: 1.0.0-beta.11
environment: ReactNative 0.77.1 and New Architecture enabled (set maintainVisibleContentPosition, recycleItems enabled)