### PR TITLE
Fix/forward ref generic

### DIFF
--- a/src/LegendList.tsx
+++ b/src/LegendList.tsx
@@ -38,6 +38,7 @@ import type {
     ViewabilityAmountCallback,
     ViewabilityCallback,
 } from "./types";
+import { typedForwardRef } from "./types";
 import { useCombinedRef } from "./useCombinedRef";
 import { useInit } from "./useInit";
 import { setupViewability, updateViewableItems } from "./viewability";
@@ -45,14 +46,16 @@ import { setupViewability, updateViewableItems } from "./viewability";
 const DEFAULT_DRAW_DISTANCE = 250;
 const DEFAULT_ITEM_SIZE = 100;
 
-export const LegendList: <T>(props: LegendListProps<T> & { ref?: ForwardedRef<LegendListRef> }) => ReactElement =
-    forwardRef(function LegendList<T>(props: LegendListProps<T>, forwardedRef: ForwardedRef<LegendListRef>) {
-        return (
-            <StateProvider>
-                <LegendListInner {...props} ref={forwardedRef} />
-            </StateProvider>
-        );
-    }) as never;
+export const LegendList = typedForwardRef(function LegendList<T>(
+    props: LegendListProps<T>,
+    forwardedRef: ForwardedRef<LegendListRef>,
+) {
+    return (
+        <StateProvider>
+            <LegendListInner {...props} ref={forwardedRef} />
+        </StateProvider>
+    );
+});
 
 const LegendListInner: <T>(props: LegendListProps<T> & { ref?: ForwardedRef<LegendListRef> }) => ReactElement =
     forwardRef(function LegendListInner<T>(props: LegendListProps<T>, forwardedRef: ForwardedRef<LegendListRef>) {

--- a/src/LegendList.tsx
+++ b/src/LegendList.tsx
@@ -1,15 +1,6 @@
 // biome-ignore lint/style/useImportType: Some uses crash if importing React is missing
 import * as React from "react";
-import {
-    type ForwardedRef,
-    type ReactElement,
-    forwardRef,
-    useCallback,
-    useEffect,
-    useImperativeHandle,
-    useMemo,
-    useRef,
-} from "react";
+import { type ForwardedRef, useCallback, useEffect, useImperativeHandle, useMemo, useRef } from "react";
 import {
     Dimensions,
     type LayoutChangeEvent,
@@ -57,8 +48,10 @@ export const LegendList = typedForwardRef(function LegendList<T>(
     );
 });
 
-const LegendListInner: <T>(props: LegendListProps<T> & { ref?: ForwardedRef<LegendListRef> }) => ReactElement =
-    forwardRef(function LegendListInner<T>(props: LegendListProps<T>, forwardedRef: ForwardedRef<LegendListRef>) {
+const LegendListInner = typedForwardRef(function LegendListInner<T>(
+    props: LegendListProps<T>,
+    forwardedRef: ForwardedRef<LegendListRef>,
+) {
         const {
             data,
             initialScrollIndex,
@@ -1239,4 +1232,4 @@ const LegendListInner: <T>(props: LegendListProps<T> & { ref?: ForwardedRef<Lege
                 style={style}
             />
         );
-    }) as <T>(props: LegendListProps<T> & { ref?: ForwardedRef<LegendListRef> }) => ReactElement;
+});

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-import type { ComponentProps, ReactNode } from "react";
+import { type ComponentProps, type ReactNode, forwardRef } from "react";
 import type { ScrollResponderMixin, ScrollViewComponent, ScrollViewProps } from "react-native";
 import type { ScrollView, StyleProp, ViewStyle } from "react-native";
 import type Animated from "react-native-reanimated";
@@ -228,3 +228,10 @@ export interface LegendListRecyclingState<T> {
     index: number;
     prevIndex: number | undefined;
 }
+
+// biome-ignore lint/complexity/noBannedTypes: This is correct
+export type TypedForwardRef = <T, P = {}>(
+    render: (props: P, ref: React.Ref<T>) => React.ReactNode,
+) => (props: P & React.RefAttributes<T>) => React.ReactNode;
+
+export const typedForwardRef = forwardRef as TypedForwardRef;


### PR DESCRIPTION
I found many places where we’re using TypeScript **as** annotations to make generics work properly with forward refs. Find a way to utilize a reusable typedForwardRef that handles this under the hood.