### PR TITLE
chore: update metadata in `package.json` file

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@legendapp/list",
     "version": "1.0.0-beta.11",
-    "description": "legend-list",
+    "description": "Legend List aims to be a drop-in replacement for FlatList with much better performance and supporting dynamically sized items.",
     "sideEffects": false,
     "private": false,
     "main": "./index.js",
@@ -60,10 +60,7 @@
         "react-native",
         "list"
     ],
-    "repository": {
-        "type": "git",
-        "url": "git+https://github.com/LegendApp/legend-list.git"
-    },
+    "repository": "github:LegendApp/legend-list",
     "license": "MIT",
     "bugs": {
         "url": "https://github.com/LegendApp/legend-list/issues"


### PR DESCRIPTION
# Why

Spotted in React Native Directory that npm package does not include meaningful description.

![Screenshot 2025-03-06 at 14 10 34](https://github.com/user-attachments/assets/d97a80fa-b23f-4e04-ba50-89497c835b85)

# How

Update the package description. to the first sentence from README file, use GitHub shorthand for `repository` field, see:
* https://docs.npmjs.com/cli/v11/configuring-npm/package-json#repository