### PR TITLE
Provide leadingItem to ItemSeparatorComponent

### DIFF
--- a/src/Container.tsx
+++ b/src/Container.tsx
@@ -27,7 +27,7 @@ export const Container = ({
     id: number;
     recycleItems?: boolean;
     horizontal: boolean;
-    getRenderedItem: (key: string) => { index: number; renderedItem: React.ReactNode } | null;
+    getRenderedItem: (key: string) => { index: number; item: any; renderedItem: React.ReactNode } | null;
     updateItemSize: (containerId: number, itemKey: string, size: number) => void;
     ItemSeparatorComponent?: React.ReactNode;
 }) => {

--- a/src/Container.tsx
+++ b/src/Container.tsx
@@ -29,7 +29,7 @@ export const Container = ({
     horizontal: boolean;
     getRenderedItem: (key: string) => { index: number; item: any; renderedItem: React.ReactNode } | null;
     updateItemSize: (containerId: number, itemKey: string, size: number) => void;
-    ItemSeparatorComponent?: React.ReactNode;
+    ItemSeparatorComponent?: React.ComponentType<{ leadingItem: any }>;
 }) => {
     const ctx = useStateContext();
     const columnWrapperStyle = ctx.columnWrapperStyle;
@@ -79,7 +79,7 @@ export const Container = ({
     const extraData = use$<string>("extraData"); // to detect extraData changes
 
     const renderedItemInfo = useMemo(
-        () => itemKey !== undefined && getRenderedItem(itemKey),
+        () => (itemKey !== undefined ? getRenderedItem(itemKey) : null),
         [itemKey, data, extraData],
     );
     const { index, renderedItem } = renderedItemInfo || {};
@@ -132,7 +132,9 @@ export const Container = ({
         <React.Fragment key={recycleItems ? undefined : itemKey}>
             <ContextContainer.Provider value={contextValue}>
                 {renderedItem}
-                {renderedItem && ItemSeparatorComponent && itemKey !== lastItemKey && ItemSeparatorComponent}
+                {renderedItemInfo && ItemSeparatorComponent && itemKey !== lastItemKey && (
+                    <ItemSeparatorComponent leadingItem={renderedItemInfo.item} />
+                )}
             </ContextContainer.Provider>
         </React.Fragment>
     );

--- a/src/Container.tsx
+++ b/src/Container.tsx
@@ -16,7 +16,7 @@ import type { AnchoredPosition } from "./types";
 // @ts-expect-error nativeFabricUIManager is not defined in the global object types
 const isNewArchitecture = global.nativeFabricUIManager != null;
 
-export const Container = ({
+export const Container = <ItemT,>({
     id,
     recycleItems,
     horizontal,
@@ -27,9 +27,9 @@ export const Container = ({
     id: number;
     recycleItems?: boolean;
     horizontal: boolean;
-    getRenderedItem: (key: string) => { index: number; item: any; renderedItem: React.ReactNode } | null;
+    getRenderedItem: (key: string) => { index: number; item: ItemT; renderedItem: React.ReactNode } | null;
     updateItemSize: (containerId: number, itemKey: string, size: number) => void;
-    ItemSeparatorComponent?: React.ComponentType<{ leadingItem: any }>;
+    ItemSeparatorComponent?: React.ComponentType<{ leadingItem: ItemT }>;
 }) => {
     const ctx = useStateContext();
     const columnWrapperStyle = ctx.columnWrapperStyle;

--- a/src/Containers.tsx
+++ b/src/Containers.tsx
@@ -7,7 +7,7 @@ import { useValue$ } from "./useValue$";
 interface ContainersProps {
     horizontal: boolean;
     recycleItems: boolean;
-    ItemSeparatorComponent?: React.ReactNode;
+    ItemSeparatorComponent?: React.ComponentType<{ leadingItem: any }>;
     waitForInitialLayout: boolean | undefined;
     updateItemSize: (containerId: number, itemKey: string, size: number) => void;
     getRenderedItem: (key: string) => { index: number; item: any; renderedItem: React.ReactNode } | null;

--- a/src/Containers.tsx
+++ b/src/Containers.tsx
@@ -10,7 +10,7 @@ interface ContainersProps {
     ItemSeparatorComponent?: React.ReactNode;
     waitForInitialLayout: boolean | undefined;
     updateItemSize: (containerId: number, itemKey: string, size: number) => void;
-    getRenderedItem: (key: string) => { index: number; renderedItem: React.ReactNode } | null;
+    getRenderedItem: (key: string) => { index: number; item: any; renderedItem: React.ReactNode } | null;
 }
 
 export const Containers = React.memo(function Containers({

--- a/src/Containers.tsx
+++ b/src/Containers.tsx
@@ -1,26 +1,27 @@
-import * as React from "react";
+import type * as React from "react";
 import { Animated, type StyleProp, type ViewStyle } from "react-native";
 import { Container } from "./Container";
 import { use$ } from "./state";
+import { typedMemo } from "./types";
 import { useValue$ } from "./useValue$";
 
-interface ContainersProps {
+interface ContainersProps<ItemT> {
     horizontal: boolean;
     recycleItems: boolean;
-    ItemSeparatorComponent?: React.ComponentType<{ leadingItem: any }>;
+    ItemSeparatorComponent?: React.ComponentType<{ leadingItem: ItemT }>;
     waitForInitialLayout: boolean | undefined;
     updateItemSize: (containerId: number, itemKey: string, size: number) => void;
-    getRenderedItem: (key: string) => { index: number; item: any; renderedItem: React.ReactNode } | null;
+    getRenderedItem: (key: string) => { index: number; item: ItemT; renderedItem: React.ReactNode } | null;
 }
 
-export const Containers = React.memo(function Containers({
+export const Containers = typedMemo(function Containers<ItemT>({
     horizontal,
     recycleItems,
     ItemSeparatorComponent,
     waitForInitialLayout,
     updateItemSize,
     getRenderedItem,
-}: ContainersProps) {
+}: ContainersProps<ItemT>) {
     const numContainers = use$<number>("numContainersPooled");
     const animSize = useValue$("totalSize", undefined, /*useMicrotask*/ true);
     const animOpacity = waitForInitialLayout ? useValue$("containersDidLayout", (value) => (value ? 1 : 0)) : undefined;

--- a/src/LegendList.tsx
+++ b/src/LegendList.tsx
@@ -993,7 +993,7 @@ const LegendListInner = typedForwardRef(function LegendListInner<T>(
             useRecyclingState,
         });
 
-        return { index, renderedItem };
+        return { index, item: data[index], renderedItem };
     }, []);
 
     useInit(() => {

--- a/src/ListComponent.tsx
+++ b/src/ListComponent.tsx
@@ -28,7 +28,7 @@ interface ListComponentProps
     horizontal: boolean;
     initialContentOffset: number | undefined;
     refScrollView: React.Ref<ScrollView>;
-    getRenderedItem: (key: string) => { index: number; renderedItem: ReactNode } | null;
+    getRenderedItem: (key: string) => { index: number; item: any; renderedItem: ReactNode } | null;
     updateItemSize: (containerId: number, itemKey: string, size: number) => void;
     handleScroll: (event: NativeSyntheticEvent<NativeScrollEvent>) => void;
     onLayout: (event: LayoutChangeEvent) => void;

--- a/src/ListComponent.tsx
+++ b/src/ListComponent.tsx
@@ -12,12 +12,12 @@ import {
 import { Containers } from "./Containers";
 import { ENABLE_DEVMODE } from "./constants";
 import { peek$, set$, useStateContext } from "./state";
-import type { LegendListProps } from "./types";
+import { type LegendListProps, typedMemo } from "./types";
 import { useValue$ } from "./useValue$";
 
-interface ListComponentProps
+interface ListComponentProps<ItemT>
     extends Omit<
-        LegendListProps<any>,
+        LegendListProps<ItemT>,
         | "data"
         | "estimatedItemSize"
         | "drawDistance"
@@ -28,7 +28,7 @@ interface ListComponentProps
     horizontal: boolean;
     initialContentOffset: number | undefined;
     refScrollView: React.Ref<ScrollView>;
-    getRenderedItem: (key: string) => { index: number; item: any; renderedItem: ReactNode } | null;
+    getRenderedItem: (key: string) => { index: number; item: ItemT; renderedItem: ReactNode } | null;
     updateItemSize: (containerId: number, itemKey: string, size: number) => void;
     handleScroll: (event: NativeSyntheticEvent<NativeScrollEvent>) => void;
     onLayout: (event: LayoutChangeEvent) => void;
@@ -100,7 +100,7 @@ const PaddingAndAdjustDevMode = () => {
     );
 };
 
-export const ListComponent = React.memo(function ListComponent({
+export const ListComponent = typedMemo(function ListComponent<ItemT>({
     style,
     contentContainerStyle,
     horizontal,
@@ -122,7 +122,7 @@ export const ListComponent = React.memo(function ListComponent({
     maintainVisibleContentPosition,
     renderScrollComponent,
     ...rest
-}: ListComponentProps) {
+}: ListComponentProps<ItemT>) {
     const ctx = useStateContext();
 
     // Use renderScrollComponent if provided, otherwise a regular ScrollView

--- a/src/ListComponent.tsx
+++ b/src/ListComponent.tsx
@@ -197,7 +197,7 @@ export const ListComponent = React.memo(function ListComponent({
                 recycleItems={recycleItems!}
                 waitForInitialLayout={waitForInitialLayout}
                 getRenderedItem={getRenderedItem}
-                ItemSeparatorComponent={ItemSeparatorComponent && getComponent(ItemSeparatorComponent)}
+                ItemSeparatorComponent={ItemSeparatorComponent}
                 updateItemSize={updateItemSize}
             />
             {ListFooterComponent && <View style={ListFooterComponentStyle}>{getComponent(ListFooterComponent)}</View>}

--- a/src/reanimated.tsx
+++ b/src/reanimated.tsx
@@ -3,7 +3,13 @@ import React, { type ComponentProps } from "react";
 import Animated from "react-native-reanimated";
 import { useCombinedRef } from "./useCombinedRef";
 
-type KeysToOmit = "getEstimatedItemSize" | "keyExtractor" | "animatedProps" | "renderItem" | "onItemSizeChanged";
+type KeysToOmit =
+    | "getEstimatedItemSize"
+    | "keyExtractor"
+    | "animatedProps"
+    | "renderItem"
+    | "onItemSizeChanged"
+    | "ItemSeparatorComponent";
 
 type PropsBase<ItemT> = LegendListPropsBase<ItemT, ComponentProps<typeof Animated.ScrollView>>;
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-import { type ComponentProps, type ReactNode, forwardRef } from "react";
+import { type ComponentProps, type ReactNode, forwardRef, memo } from "react";
 import type { ScrollResponderMixin, ScrollViewComponent, ScrollViewProps } from "react-native";
 import type { ScrollView, StyleProp, ViewStyle } from "react-native";
 import type Animated from "react-native-reanimated";
@@ -242,3 +242,10 @@ export type TypedForwardRef = <T, P = {}>(
 ) => (props: P & React.RefAttributes<T>) => React.ReactNode;
 
 export const typedForwardRef = forwardRef as TypedForwardRef;
+
+export type TypedMemo = <T extends React.ComponentType<any>>(
+    Component: T,
+    propsAreEqual?: (prevProps: Readonly<ComponentProps<T>>, nextProps: Readonly<ComponentProps<T>>) => boolean,
+) => T & { displayName?: string };
+
+export const typedMemo = memo as TypedMemo;

--- a/src/types.ts
+++ b/src/types.ts
@@ -38,7 +38,7 @@ export type LegendListPropsBase<
     ListFooterComponent?: React.ComponentType<any> | React.ReactElement | null | undefined;
     ListFooterComponentStyle?: StyleProp<ViewStyle> | undefined;
     ListEmptyComponent?: React.ComponentType<any> | React.ReactElement | null | undefined;
-    ItemSeparatorComponent?: React.ComponentType<any>;
+    ItemSeparatorComponent?: React.ComponentType<{ leadingItem: ItemT }>;
     viewabilityConfigCallbackPairs?: ViewabilityConfigCallbackPairs | undefined;
     viewabilityConfig?: ViewabilityConfig;
     onViewableItemsChanged?: OnViewableItemsChanged | undefined;


### PR DESCRIPTION
Fixes https://github.com/LegendApp/legend-list/issues/113

Typing leadingItem correctly in internal components requires a generic type and some memo typing shenanigans. I could fallback to "any" if this additional complexity is unwanted.

I did not add trailingItem since FlatList docs only mention [leadingItem](https://reactnative.dev/docs/flatlist#itemseparatorcomponent). Supporting trailingItem would be a bit more work to find the next item and inject it in render.