### PR TITLE
fix: refreshing control

### DIFF
--- a/src/LegendList.tsx
+++ b/src/LegendList.tsx
@@ -1362,15 +1362,15 @@ const LegendListInner = typedForwardRef(function LegendListInner<T>(
                 scrollEventThrottle={scrollEventThrottle ?? (Platform.OS === "web" ? 16 : undefined)}
                 waitForInitialLayout={waitForInitialLayout}
                 refreshControl={
-                    props.refreshControl == null ? (
+                    props.refreshControl ? (
+                        props.refreshControl
+                    ) : refreshing ? (
                         <RefreshControl
                             refreshing={!!refreshing}
                             onRefresh={onRefresh}
                             progressViewOffset={progressViewOffset}
                         />
-                    ) : (
-                        props.refreshControl
-                    )
+                    ) : undefined
                 }
                 style={style}
             />


### PR DESCRIPTION
Fix the refreshing control
If none prodived it wont automatically apply one.
if refreshing=true it will use the default RefreshControl, unless custom one provided