### PR TITLE
Batch layout

### DIFF
--- a/src/Container.tsx
+++ b/src/Container.tsx
@@ -22,7 +22,7 @@ export const Container = <ItemT,>({
     recycleItems?: boolean;
     horizontal: boolean;
     getRenderedItem: (key: string) => { index: number; item: ItemT; renderedItem: React.ReactNode } | null;
-    updateItemSize: (containerId: number, itemKey: string, size: number) => void;
+    updateItemSize: (itemKey: string, size: number) => void;
     ItemSeparatorComponent?: React.ComponentType<{ leadingItem: ItemT }>;
 }) => {
     const ctx = useStateContext();
@@ -94,7 +94,7 @@ export const Container = <ItemT,>({
                 return;
             }
             refLastSize.current = size;
-            updateItemSize(id, itemKey, size);
+            updateItemSize(itemKey, size);
 
             // const otherAxisSize = horizontal ? event.nativeEvent.layout.width : event.nativeEvent.layout.height;
             // set$(ctx, "otherAxisSize", Math.max(otherAxisSize, peek$(ctx, "otherAxisSize") || 0));
@@ -112,7 +112,7 @@ export const Container = <ItemT,>({
                     const size = Math.floor(measured[horizontal ? "width" : "height"] * 8) / 8;
 
                     if (size) {
-                        updateItemSize(id, itemKey, size);
+                        updateItemSize(itemKey, size);
                     }
                 }
             }
@@ -127,7 +127,7 @@ export const Container = <ItemT,>({
             if (itemKey) {
                 const timeout = setTimeout(() => {
                     if (!didLayout && refLastSize.current) {
-                        updateItemSize(id, itemKey, refLastSize.current);
+                        updateItemSize(itemKey, refLastSize.current);
                     }
                 }, 16);
                 return () => {

--- a/src/LegendList.tsx
+++ b/src/LegendList.tsx
@@ -1060,7 +1060,7 @@ const LegendListInner = typedForwardRef(function LegendListInner<T>(
         doInitialAllocateContainers();
     });
 
-    const updateItemSize = useCallback((containerId: number, itemKey: string, size: number) => {
+    const updateItemSize = useCallback((itemKey: string, size: number) => {
         const state = refState.current!;
         const { sizes, indexByKey, sizesLaidOut, data, rowHeights } = state;
         if (!data) {

--- a/src/LegendList.tsx
+++ b/src/LegendList.tsx
@@ -200,6 +200,7 @@ const LegendListInner = typedForwardRef(function LegendListInner<T>(
             enableScrollForNextCalculateItemsInView: true,
             minIndexSizeChanged: 0,
             numPendingInitialLayout: 0,
+            queuedCalculateItemsInView: 0,
         };
 
         if (maintainVisibleContentPosition) {
@@ -1155,7 +1156,12 @@ const LegendListInner = typedForwardRef(function LegendListInner<T>(
                 (Number.isNaN(scrollVelocity) || Math.abs(scrollVelocity) < 1) &&
                 (!waitForInitialLayout || state.numPendingInitialLayout < 0)
             ) {
-                calculateItemsInView(state.scrollVelocity);
+                if (!state.queuedCalculateItemsInView) {
+                    state.queuedCalculateItemsInView = requestAnimationFrame(() => {
+                        state.queuedCalculateItemsInView = undefined;
+                        calculateItemsInView(state.scrollVelocity);
+                    });
+                }
             }
         }
     }, []);

--- a/src/ListComponent.tsx
+++ b/src/ListComponent.tsx
@@ -29,7 +29,7 @@ interface ListComponentProps<ItemT>
     initialContentOffset: number | undefined;
     refScrollView: React.Ref<ScrollView>;
     getRenderedItem: (key: string) => { index: number; item: ItemT; renderedItem: ReactNode } | null;
-    updateItemSize: (containerId: number, itemKey: string, size: number) => void;
+    updateItemSize: (itemKey: string, size: number) => void;
     handleScroll: (event: NativeSyntheticEvent<NativeScrollEvent>) => void;
     onLayout: (event: LayoutChangeEvent) => void;
     maintainVisibleContentPosition: boolean;

--- a/src/types.ts
+++ b/src/types.ts
@@ -91,7 +91,7 @@ export interface InternalState {
     isAtBottom: boolean;
     isAtTop: boolean;
     data: readonly any[];
-    hasScrolled: boolean;
+    hasScrolled?: boolean;
     scrollLength: number;
     startBuffered: number;
     startBufferedId?: string;
@@ -121,6 +121,7 @@ export interface InternalState {
     minIndexSizeChanged: number | undefined;
     numPendingInitialLayout: number; // 0 if first load, -1 if done
     queuedCalculateItemsInView: number | undefined;
+    lastBatchingAction: number;
 }
 
 export interface ViewableRange<T> {

--- a/src/types.ts
+++ b/src/types.ts
@@ -120,6 +120,7 @@ export interface InternalState {
     enableScrollForNextCalculateItemsInView: boolean;
     minIndexSizeChanged: number | undefined;
     numPendingInitialLayout: number; // 0 if first load, -1 if done
+    queuedCalculateItemsInView: number;
 }
 
 export interface ViewableRange<T> {
@@ -161,7 +162,12 @@ export type LegendListRef = {
      */
     scrollToEnd(options?: { animated?: boolean | undefined }): void;
 
-    scrollToIndex: (params: { index: number; animated?: boolean; viewOffset?: number; viewPosition?: number }) => void;
+    scrollToIndex: (params: {
+        index: number;
+        animated?: boolean;
+        viewOffset?: number;
+        viewPosition?: number;
+    }) => void;
 
     scrollToItem(params: { animated?: boolean; item: any; viewPosition?: number }): void;
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -120,7 +120,7 @@ export interface InternalState {
     enableScrollForNextCalculateItemsInView: boolean;
     minIndexSizeChanged: number | undefined;
     numPendingInitialLayout: number; // 0 if first load, -1 if done
-    queuedCalculateItemsInView: number;
+    queuedCalculateItemsInView: number | undefined;
 }
 
 export interface ViewableRange<T> {


### PR DESCRIPTION
This batches the size calculations from onLayout in a requestAnimationFrame. This has the benefit of reducing the number of times calculateItemsInView is called from size changing, at the expense of slightly delaying position adjustment.

I think we may want to have this behavior by default as *I think* it would generally increase scrolling performance and the case where multiple items change size. On the other hand it could increase gapping since it delays position updates by a frame. That might only be worse than now if a single item is laying out though?

If this generally works better we could default it to this, but have a way to control it:
1. A prop `batchLayouts` enabled by default, and can disable it
2. A function `syncLayout` (or a better name) which has a callback parameter and calls that callback with batching disabled. That could be for when the user is manually changing one item's size, like with tapping a card in the cards example or in an onChange handler in a TextInput.
3. Or should it be disabled by default?

Or maybe this is just a bad change. I've only tested on iOS simulator and rn-macOS so far, but I'll test on Android shortly. Please let me know how it looks on your devices.

This problem may not be as noticeable in mobile apps, but it could be super bad on a desktop or tablet with lots of things changing often, like when resizing a window. Example in my macOS photos app:

## Before:

https://github.com/user-attachments/assets/d13af7ae-c794-4ef4-b310-33a4093b6814

## After:

https://github.com/user-attachments/assets/2e5f48d1-5d42-4d4a-a0a9-4862af58ec90

