### PR TITLE
Fix flash when prepending items in onStartReached

### DIFF
--- a/src/LegendList.tsx
+++ b/src/LegendList.tsx
@@ -939,6 +939,11 @@ const LegendListInner = typedForwardRef(function LegendListInner<T>(
         if (maxSizeInRow > 0) {
             totalSize += maxSizeInRow;
         }
+        const state = refState.current;
+        state.ignoreScrollFromCalcTotal = true;
+        requestAnimationFrame(() => {
+            state.ignoreScrollFromCalcTotal = false;
+        });
         addTotalSize(null, totalSize, totalSizeBelowIndex);
     };
 
@@ -1224,6 +1229,10 @@ const LegendListInner = typedForwardRef(function LegendListInner<T>(
             }
 
             const state = refState.current!;
+            if (state.ignoreScrollFromCalcTotal) {
+                return;
+            }
+
             state.hasScrolled = true;
             state.lastBatchingAction = Date.now();
             const currentTime = performance.now();

--- a/src/types.ts
+++ b/src/types.ts
@@ -122,6 +122,7 @@ export interface InternalState {
     numPendingInitialLayout: number; // 0 if first load, -1 if done
     queuedCalculateItemsInView: number | undefined;
     lastBatchingAction: number;
+    ignoreScrollFromCalcTotal?: boolean;
 }
 
 export interface ViewableRange<T> {


### PR DESCRIPTION
Ignore scroll events immediately following calcTotalSizesAndPositions, which fixes the flash when prepending items in onStartReached