### PR TITLE
Improve / Beautify README and Add MouseOver DX Tooltips to Properties and Ref Functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ Beyond standard `FlatList` capabilities:
 
 *   `maintainScrollAtEnd`: (boolean) If `true` and the user is scrolled near the bottom (within `maintainScrollAtEndThreshold * screen height`), the list automatically scrolls to the end when items are added or heights change. Ideal for chat interfaces.
 *   `recycleItems`: (boolean) Toggles item component recycling.
-    *   `true` (default): Reuses item components for optimal performance. Be cautious if your item components contain local state, as it might be reused unexpectedly.
-    *   `false`: Creates new item components every time. Less performant but safer if items have complex internal state.
+    *   `true`: Reuses item components for optimal performance. Be cautious if your item components contain local state, as it might be reused unexpectedly.
+    *   `false` (default): Creates new item components every time. Less performant but safer if items have complex internal state.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -75,7 +75,6 @@ const LegendListExample = () => {
     const listRef = useRef<LegendListRef | null>(null);
 
     const renderItem = ({ item }: LegendListRenderItemProps<UserData>) => {
-
         return (
             <View style={styles.itemContainer}>
                 <Image style={styles.profilePic} source={{ uri: item.photoUri }} />

--- a/README.md
+++ b/README.md
@@ -1,64 +1,121 @@
-# Legend List
+# Legend List 
 
-Legend List aims to be a drop-in replacement for FlatList with much better performance and supporting dynamically sized items.
+**Legend List** is a high-performance list component for **React Native**, written purely in Javascript / Typescript (no native dependencies). It aims to be a drop-in replacement for `FlatList` and/or `FlashList` with better performance, especially when handling dynamically sized items.
 
-## Caution: Experimental
+---
 
-This is an early release to test and gather feedback. It's not used in production yet and needs more work to reach parity with FlatList features.
+## ⚠️ Caution: Experimental ⚠️ 
 
-## Features
+This is an early release to test and gather feedback. It's not used in production yet and needs more work to reach parity with FlatList (and FlashList) features.
 
-In addition to normal FlatList features:
+---
 
--   Dynamic layouts supported. Just use the `estimatedItemSize` prop to give a close estimate so that layouts aren't too far off, and positions will adjust while rendering.
--   `maintainScrollAtEnd`: If true and scroll is within `maintainScrollAtEndThreshold * screen height` then changing items or heights will scroll to the bottom. This can be useful for chat interfaces.
--   `recycleItems` prop enables toggling recycling of list items. If enabled it will reuse item components for improved performance, but it will reuse any local state in items. So if you have local state in items you likely want this disabled.
+## 🤔 Why Legend List?
 
-## Documentation
+*   **Performance:** Designed from the ground up for speed, aiming to outperform `FlatList` in common scenarios.
+*   **Dynamic Item Sizes:** Natively supports items with varying heights without performance hits. Just provide an `estimatedItemSize`.
+*   **Drop-in Potential:** Aims for API compatibility with `FlatList` for easier migration.
+*   **Pure JS/TS:** No native module linking required, ensuring easier integration and compatibility across platforms.
+*   **Lightweight:** Our goal is to keep LegendList as small of a dependency as possible. For more advanced use cases, we plan on supporting optional plugins. This ensures that we keep the package size as small as possible.
 
-See the [documentation site](https://www.legendapp.com/open-source/list) for the full documentation.
+For more information, listen to the podcast we had on [React Native Radio](https://infinite.red/react-native-radio/rnr-325-legend-list-with-jay-meistrich)!
 
-## Usage
+---
+## ✨ Additional Features 
 
-## Install
+Beyond standard `FlatList` capabilities:
 
-`bun add @legendapp/list` or `npm install @legendapp/list` or `yarn add @legendapp/list`
+*   `maintainScrollAtEnd`: (boolean) If `true` and the user is scrolled near the bottom (within `maintainScrollAtEndThreshold * screen height`), the list automatically scrolls to the end when items are added or heights change. Ideal for chat interfaces.
+*   `recycleItems`: (boolean) Toggles item component recycling.
+    *   `true` (default): Reuses item components for optimal performance. Be cautious if your item components contain local state, as it might be reused unexpectedly.
+    *   `false`: Creates new item components every time. Less performant but safer if items have complex internal state.
 
-### Props
+---
 
-We suggest using all of the required props and additionally `keyExtractor` to improve performance when adding/removing items.
+## 📚 Documentation (In Progress)
 
-#### Required
+For comprehensive documentation, guides, and the full API reference, please visit:
 
-```ts
-interface PropsRequired {
-    data: ArrayLike<any> & T[];
-    renderItem: (props: LegendListRenderItemInfo<T>) => ReactNode;
-    estimatedItemSize: number;
-}
+➡️ **[Legend List Documentation Site](https://www.legendapp.com/open-source/list)**
+
+---
+
+## 💻 Usage
+
+### Installation
+
+```bash
+# Using Bun
+bun add @legendapp/list
+
+# Using npm
+npm install @legendapp/list
+
+# Using Yarn
+yarn add @legendapp/list
 ```
 
-#### Optional
-
+### Example
 ```ts
-interface PropsOptional {
-    initialScrollOffset?: number;
-    initialScrollIndex?: number;
-    drawDistance?: number;
-    recycleItems?: boolean;
-    onEndReachedThreshold?: number | null | undefined;
-    maintainScrollAtEnd?: boolean;
-    maintainScrollAtEndThreshold?: number;
-    onEndReached?: ((info: { distanceFromEnd: number }) => void) | null | undefined;
-    keyExtractor?: (item: T, index: number) => string;
+import React, { useRef } from "react"; 
+import { View, Image, Text, StyleSheet } from "react-native";
+import { LegendList, LegendListRef, LegendListRenderItemProps } from "@legendapp/list";
+import { userData } from "../userData"; // Assuming userData is defined elsewhere
+
+// Define the type for your data items
+interface UserData {
+    id: string;
+    name: string;
+    photoUri: string;
 }
+
+const LegendListExample = () => {
+
+    // Optional: Ref for accessing list methods (e.g., scrollTo)
+    const listRef = useRef<LegendListRef | null>(null);
+
+    const renderItem = ({ item }: LegendListRenderItemProps<UserData>) => {
+
+        return (
+            <View style={styles.itemContainer}>
+                <Image style={styles.profilePic} source={{ uri: item.photoUri }} />
+                <Text style={styles.name}>{item.name}</Text>
+            </View>
+        );
+    };
+
+    return (
+        <LegendList<UserData>
+            // Required Props
+            data={data}
+            renderItem={renderItem} 
+            estimatedItemSize={70} 
+
+            // Strongly Recommended Prop (Improves performance)
+            keyExtractor={(item) => item.id} 
+
+            // Optional Props
+            ref={listRef} 
+            recycleItems={true}   
+            maintainScrollAtEnd={false} 
+            maintainScrollAtEndThreshold={1} 
+
+            // See docs for all available props!
+        />
+    );
+};
+
+export default LegendListExample;
+
 ```
 
-## How to build
+---
+
+## How to Build
 
 `npm run build` will build the package to the `dist` folder.
 
-## How to run example
+## Running the Example
 
 1. `cd example`
 2. `npm i`

--- a/src/types.ts
+++ b/src/types.ts
@@ -14,57 +14,219 @@ export type LegendListPropsBase<
     ItemT,
     TScrollView extends ComponentProps<typeof ScrollView> | ComponentProps<typeof Animated.ScrollView>,
 > = Omit<TScrollView, "contentOffset" | "contentInset" | "maintainVisibleContentPosition" | "stickyHeaderIndices"> & {
-    data: ReadonlyArray<ItemT>;
-    initialScrollOffset?: number;
-    initialScrollIndex?: number;
-    drawDistance?: number;
-    recycleItems?: boolean;
-    onEndReachedThreshold?: number | null | undefined;
-    onStartReachedThreshold?: number | null | undefined;
-    maintainScrollAtEnd?: boolean;
-    maintainScrollAtEndThreshold?: number;
-    alignItemsAtEnd?: boolean;
-    maintainVisibleContentPosition?: boolean;
-    numColumns?: number;
-    columnWrapperStyle?: ColumnWrapperStyle;
-    refScrollView?: React.Ref<ScrollView>;
-    waitForInitialLayout?: boolean;
-    initialContainerPoolRatio?: number | undefined;
-    // in most cases providing a constant value for item size enough
-    estimatedItemSize?: number;
-    // in case you have distinct item sizes, you can provide a function to get the size of an item
-    // use instead of FlatList's getItemLayout or FlashList overrideItemLayout
-    // if you want to have accurate initialScrollOffset, you should provide this function
-    getEstimatedItemSize?: (index: number, item: ItemT) => number;
-    onStartReached?: ((info: { distanceFromStart: number }) => void) | null | undefined;
-    onEndReached?: ((info: { distanceFromEnd: number }) => void) | null | undefined;
-    keyExtractor?: (item: ItemT, index: number) => string;
-    renderItem?: (props: LegendListRenderItemProps<ItemT>) => ReactNode;
-    ListHeaderComponent?: React.ComponentType<any> | React.ReactElement | null | undefined;
-    ListHeaderComponentStyle?: StyleProp<ViewStyle> | undefined;
-    ListFooterComponent?: React.ComponentType<any> | React.ReactElement | null | undefined;
-    ListFooterComponentStyle?: StyleProp<ViewStyle> | undefined;
-    ListEmptyComponent?: React.ComponentType<any> | React.ReactElement | null | undefined;
-    ItemSeparatorComponent?: React.ComponentType<{ leadingItem: ItemT }>;
-    viewabilityConfigCallbackPairs?: ViewabilityConfigCallbackPairs | undefined;
-    viewabilityConfig?: ViewabilityConfig;
-    onViewableItemsChanged?: OnViewableItemsChanged | undefined;
-    onItemSizeChanged?: (info: {
-        size: number;
-        previous: number;
-        index: number;
-        itemKey: string;
-        itemData: ItemT;
-    }) => void;
-    /**
-     * Render custom ScrollView component.
-     * @default (props) => <ScrollView {...props} />
+   /**
+     * If true, aligns items at the end of the list.
+     * @default false
      */
-    renderScrollComponent?: (props: ScrollViewProps) => React.ReactElement<ScrollViewProps>;
-    extraData?: any;
-    refreshing?: boolean;
-    onRefresh?: () => void;
-    progressViewOffset?: number;
+   alignItemsAtEnd?: boolean;
+
+   /**
+    * Style applied to each column's wrapper view.
+    */
+   columnWrapperStyle?: ColumnWrapperStyle;
+
+   /**
+    * Array of items to render in the list.
+    * @required
+    */
+   data: ReadonlyArray<ItemT>;
+
+   /**
+    * Distance in pixels to pre-render items ahead of the visible area.
+    * @default 250
+    */
+   drawDistance?: number;
+
+   /**
+    * Estimated size of each item in pixels; sufficient for most cases. If
+    * you leave this blank, a warning should appear and you will get
+    * a suggested size.
+    * @required
+    * @default undefined
+    */
+   estimatedItemSize?: number;
+
+   /**
+    * Extra data to trigger re-rendering when changed.
+    */
+   extraData?: any;
+
+   /**
+    * In case you have distinct item sizes, you can provide a function to get the size of an item.
+    * Use instead of FlatList's getItemLayout or FlashList overrideItemLayout if you want to have accurate initialScrollOffset, you should provide this function
+    */
+   getEstimatedItemSize?: (index: number, item: ItemT) => number;
+
+   /**
+    * Ratio of initial container pool size to data length (e.g., 0.5 for half).
+    * @default 1
+    */
+   initialContainerPoolRatio?: number | undefined;
+
+   /**
+    * Initial scroll position in pixels.
+    * @default 0
+    */
+   initialScrollOffset?: number;
+
+   /**
+    * Index to scroll to initially.
+    * @default 0
+    */
+   initialScrollIndex?: number;
+
+   /**
+    * Component to render between items, receiving the leading item as prop.
+    */
+   ItemSeparatorComponent?: React.ComponentType<{ leadingItem: ItemT }>;
+
+   /**
+    * Function to extract a unique key for each item.
+    */
+   keyExtractor?: (item: ItemT, index: number) => string;
+
+   /**
+    * Component or element to render when the list is empty.
+    */
+   ListEmptyComponent?: React.ComponentType<any> | React.ReactElement | null | undefined;
+
+   /**
+    * Component or element to render below the list.
+    */
+   ListFooterComponent?: React.ComponentType<any> | React.ReactElement | null | undefined;
+
+   /**
+    * Style for the footer component.
+    */
+   ListFooterComponentStyle?: StyleProp<ViewStyle> | undefined;
+
+   /**
+    * Component or element to render above the list.
+    */
+   ListHeaderComponent?: React.ComponentType<any> | React.ReactElement | null | undefined;
+
+   /**
+    * Style for the header component.
+    */
+   ListHeaderComponentStyle?: StyleProp<ViewStyle> | undefined;
+
+   /**
+    * If true, auto-scrolls to end when new items are added.
+    * @default false
+    */
+   maintainScrollAtEnd?: boolean;
+
+   /**
+    * Distance threshold in pixels to trigger maintainScrollAtEnd.
+    * @default 100
+    */
+   maintainScrollAtEndThreshold?: number;
+
+   /**
+    * If true, maintains visibility of content during scroll (e.g., after insertions).
+    * @default false
+    */
+   maintainVisibleContentPosition?: boolean;
+
+   /**
+    * Number of columns to render items in.
+    * @default 1
+    */
+   numColumns?: number;
+
+   /**
+    * Called when scrolling reaches the end within onEndReachedThreshold.
+    */
+   onEndReached?: ((info: { distanceFromEnd: number }) => void) | null | undefined;
+
+   /**
+    * How close to the end (in fractional units of visible length) to trigger onEndReached.
+    * @default 0.5
+    */
+   onEndReachedThreshold?: number | null | undefined;
+
+   /**
+    * Called when an item's size changes.
+    */
+   onItemSizeChanged?: (info: {
+       size: number;
+       previous: number;
+       index: number;
+       itemKey: string;
+       itemData: ItemT;
+   }) => void;
+
+   /**
+    * Function to call when the user pulls to refresh.
+    */
+   onRefresh?: () => void;
+
+   /**
+    * Called when scrolling reaches the start within onStartReachedThreshold.
+    */
+   onStartReached?: ((info: { distanceFromStart: number }) => void) | null | undefined;
+
+   /**
+    * How close to the start (in fractional units of visible length) to trigger onStartReached.
+    * @default 0.5
+    */
+   onStartReachedThreshold?: number | null | undefined;
+
+   /**
+    * Called when the viewability of items changes.
+    */
+   onViewableItemsChanged?: OnViewableItemsChanged | undefined;
+
+   /**
+    * Offset in pixels for the refresh indicator.
+    * @default 0
+    */
+   progressViewOffset?: number;
+
+   /**
+    * If true, recycles item views for better performance.
+    * @default false
+    */
+   recycleItems?: boolean;
+
+   /**
+    * Ref to the underlying ScrollView component.
+    */
+   refScrollView?: React.Ref<ScrollView>;
+
+   /**
+    * If true, shows a refresh indicator.
+    * @default false
+    */
+   refreshing?: boolean;
+
+   /**
+    * Function to render each item in the list.
+    * @required
+    */
+   renderItem?: (props: LegendListRenderItemProps<ItemT>) => ReactNode;
+
+   /**
+    * Render custom ScrollView component.
+    * @default (props) => <ScrollView {...props} />
+    */
+   renderScrollComponent?: (props: ScrollViewProps) => React.ReactElement<ScrollViewProps>;
+
+   /**
+    * Configuration for determining item viewability.
+    */
+   viewabilityConfig?: ViewabilityConfig;
+
+   /**
+    * Pairs of viewability configs and their callbacks for tracking visibility.
+    */
+   viewabilityConfigCallbackPairs?: ViewabilityConfigCallbackPairs | undefined;
+
+   /**
+    * If true, delays rendering until initial layout is complete.
+    * @default false
+    */
+   waitForInitialLayout?: boolean;
 };
 
 export interface ColumnWrapperStyle {
@@ -152,26 +314,40 @@ export interface LegendListRenderItemProps<ItemT> {
 
 export type LegendListRef = {
     /**
-     * Displays the scroll indicators momentarily.
-     */
+         * Displays the scroll indicators momentarily.
+         */
     flashScrollIndicators(): void;
 
+    /**
+     * Returns the native ScrollView component reference.
+     */
     getNativeScrollRef(): React.ElementRef<typeof ScrollViewComponent>;
 
-    getScrollResponder(): ScrollResponderMixin;
-
+    /**
+     * Returns the scroll responder instance for handling scroll events.
+     */
     getScrollableNode(): any;
 
     /**
-     * A helper function that scrolls to the end of the scrollview;
-     * If this is a vertical ScrollView, it scrolls to the bottom.
-     * If this is a horizontal ScrollView scrolls to the right.
-     *
-     * The options object has an animated prop, that enables the scrolling animation or not.
-     * The animated prop defaults to true
+     * Returns the ScrollResponderMixin for advanced scroll handling.
+     */
+    getScrollResponder(): ScrollResponderMixin;
+
+    /**
+     * Scrolls to the end of the list.
+     * @param options - Options for scrolling.
+     * @param options.animated - If true, animates the scroll. Default: true.
      */
     scrollToEnd(options?: { animated?: boolean | undefined }): void;
 
+    /**
+     * Scrolls to a specific index in the list.
+     * @param params - Parameters for scrolling.
+     * @param params.animated - If true, animates the scroll. Default: true.
+     * @param params.index - The index to scroll to.
+     * @param params.viewOffset - Offset from the target position.
+     * @param params.viewPosition - Position of the item in the viewport (0 to 1).
+     */
     scrollToIndex(params: {
         animated?: boolean | undefined;
         index: number;
@@ -179,6 +355,14 @@ export type LegendListRef = {
         viewPosition?: number | undefined;
     }): void;
 
+    /**
+     * Scrolls to a specific item in the list.
+     * @param params - Parameters for scrolling.
+     * @param params.animated - If true, animates the scroll. Default: true.
+     * @param params.item - The item to scroll to.
+     * @param params.viewOffset - Offset from the target position.
+     * @param params.viewPosition - Position of the item in the viewport (0 to 1).
+     */
     scrollToItem(params: {
         animated?: boolean | undefined;
         item: any;
@@ -186,6 +370,12 @@ export type LegendListRef = {
         viewPosition?: number | undefined;
     }): void;
 
+    /**
+     * Scrolls to a specific offset in pixels.
+     * @param params - Parameters for scrolling.
+     * @param params.offset - The pixel offset to scroll to.
+     * @param params.animated - If true, animates the scroll. Default: true.
+     */
     scrollToOffset(params: { offset: number; animated?: boolean | undefined }): void;
 };
 


### PR DESCRIPTION
Hey @jmeistrich,

I wanted to contribute somehow so I did a little work improving the ReadMe and I also added some tooltip comments in `types.ts` to  help with DX. It's just a start I suppose. 

I reworked the README example, but feel free to take it or leave it. I have always preferred as a Developer to just immediately see the usage (imports and all) right on the README. 

Thanks again,
Chris