### PR TITLE
Prevent app crash when data value is undefined

### DIFF
--- a/src/LegendList.tsx
+++ b/src/LegendList.tsx
@@ -56,7 +56,7 @@ const LegendListInner = typedForwardRef(function LegendListInner<T>(
     forwardedRef: ForwardedRef<LegendListRef>,
 ) {
     const {
-        data: dataProp,
+        data: dataProp = [],
         initialScrollIndex,
         initialScrollOffset,
         horizontal,


### PR DESCRIPTION
I was using FlashList in my app and tried LegendList wich showed a better perfomance in release mode, but I've published an update and some users started getting the below error, I know that is a bug in my code but I'never get this crash before , so I added a initial value to `data` prop, so the component just show nothing instead of crash the app, this is the default behavior for FlashList and FlatList.

![image](https://github.com/user-attachments/assets/9650eef7-2f4e-469c-a7f4-ded4bd53056e)

