### PR TITLE
Fix gaps

### DIFF
--- a/example/app/cards-renderItem.tsx
+++ b/example/app/cards-renderItem.tsx
@@ -1,6 +1,6 @@
 import { MaterialIcons } from "@expo/vector-icons";
-import { LegendList, type LegendListRenderItemProps, useViewabilityAmount } from "@legendapp/list";
-import { useRef, useState } from "react";
+import { LegendList, type LegendListRenderItemProps, useRecyclingState, useViewabilityAmount } from "@legendapp/list";
+import { useRef } from "react";
 import { Animated, Image, Platform, Pressable, StyleSheet, Text, UIManager, View } from "react-native";
 import { RectButton } from "react-native-gesture-handler";
 import Swipeable, { type SwipeableMethods } from "react-native-gesture-handler/ReanimatedSwipeable";
@@ -103,7 +103,7 @@ export const ItemCard = ({ item, index }: LegendListRenderItemProps<Item>) => {
     const refSwipeable = useRef<SwipeableMethods>();
 
     // A useState that resets when the item is recycled
-    const [isExpanded, setIsExpanded] = useState(() => false);
+    const [isExpanded, setIsExpanded] = useRecyclingState(() => false);
 
     const swipeableState = useRef(false);
 

--- a/src/Container.tsx
+++ b/src/Container.tsx
@@ -36,6 +36,7 @@ export const Container = <ItemT,>({
     const data = use$<any>(`containerItemData${id}`); // to detect data changes
     const extraData = use$<string>("extraData"); // to detect extraData changes
     const refLastSize = useRef<number>();
+    const ref = useRef<View>(null);
 
     const otherAxisPos: DimensionValue | undefined = numColumns > 1 ? `${((column - 1) / numColumns) * 100}%` : 0;
     const otherAxisSize: DimensionValue | undefined = numColumns > 1 ? `${(1 / numColumns) * 100}%` : undefined;
@@ -98,7 +99,6 @@ export const Container = <ItemT,>({
         }
     };
 
-    const ref = useRef<View>(null);
     if (isNewArchitecture) {
         // New architecture supports unstable_getBoundingClientRect for getting layout synchronously
         useLayoutEffect(() => {
@@ -134,10 +134,10 @@ export const Container = <ItemT,>({
         }, [itemKey]);
     }
 
-    const contextValue = useMemo(
-        () => ({ containerId: id, itemKey, index: index!, value: data }),
-        [id, itemKey, index, data],
-    );
+    const contextValue = useMemo(() => {
+        ctx.viewRefs.set(id, ref);
+        return { containerId: id, itemKey, index: index!, value: data };
+    }, [id, itemKey, index, data]);
 
     const contentFragment = (
         <React.Fragment key={recycleItems ? undefined : itemKey}>

--- a/src/Containers.tsx
+++ b/src/Containers.tsx
@@ -25,7 +25,6 @@ export const Containers = typedMemo(function Containers<ItemT>({
 }: ContainersProps<ItemT>) {
     const ctx = useStateContext();
     const columnWrapperStyle = ctx.columnWrapperStyle;
-    const numColumns = use$<number>("numColumns");
     const numContainers = use$<number>("numContainersPooled");
     const animSize = useValue$("totalSizeWithScrollAdjust", undefined, /*useMicrotask*/ true);
     const animOpacity = waitForInitialLayout ? useValue$("containersDidLayout", (value) => (value ? 1 : 0)) : undefined;

--- a/src/state.tsx
+++ b/src/state.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
 import { useSyncExternalStore } from "react";
+import type { View } from "react-native";
 import type {
     ColumnWrapperStyle,
     ViewAmountToken,
@@ -48,6 +49,7 @@ export interface StateContext {
     mapViewabilityAmountCallbacks: Map<number, ViewabilityAmountCallback>;
     mapViewabilityAmountValues: Map<number, ViewAmountToken>;
     columnWrapperStyle: ColumnWrapperStyle | undefined;
+    viewRefs: Map<number, React.RefObject<View>>;
 }
 
 const ContextState = React.createContext<StateContext | null>(null);
@@ -66,6 +68,7 @@ export function StateProvider({ children }: { children: React.ReactNode }) {
         mapViewabilityAmountCallbacks: new Map<number, ViewabilityAmountCallback>(),
         mapViewabilityAmountValues: new Map<number, ViewAmountToken>(),
         columnWrapperStyle: undefined,
+        viewRefs: new Map<number, React.RefObject<View>>(),
     }));
     return <ContextState.Provider value={value}>{children}</ContextState.Provider>;
 }


### PR DESCRIPTION
This does two things:

### 1. Fix gaps while scrolling

When a container useLayoutEffect fires, run through all containers and if we don't already have a known size then measure the item. This is useful because when multiple items render in one frame, the first container fires a useLayoutEffect and we can measure all containers before their useLayoutEffects fire after a delay. This lets use fix any gaps/overlaps that might be visible before the useLayoutEffects fire for each container.

### 2. Fix gaps on user interaction

We were previously relying on onLayout to know when an item resized, but that would be delayed by a frame. Since useLayoutEffect fires synchronously, we can trigger the container to re-render at the same time as setting state in the item that would change the size. Then the useLayoutEffect in the container will run after the state has committed in the item and have an updated measurement.