### PR TITLE
Use right drawDistance for FlashList

### DIFF
--- a/example/app/cards-flashlist/index.tsx
+++ b/example/app/cards-flashlist/index.tsx
@@ -45,7 +45,7 @@ export default function HomeScreen() {
                 keyExtractor={(item) => item.id}
                 contentContainerStyle={styles.listContainer}
                 estimatedItemSize={ESTIMATED_ITEM_LENGTH}
-                drawDistance={DRAW_DISTANCE / 2} // FlashList seems to multiply the drawDistance internally so this makes it about even
+                drawDistance={DRAW_DISTANCE}
                 // initialScrollIndex={500}
                 ref={scrollRef}
                 ListHeaderComponent={<View />}

--- a/example/app/countries-flashlist/index.tsx
+++ b/example/app/countries-flashlist/index.tsx
@@ -85,7 +85,6 @@ const App = () => {
                     extraData={selectedId}
                     estimatedItemSize={70}
                     //scrollEventThrottle={200}
-                    drawDistance={125}
                     disableAutoLayout
                 />
             </SafeAreaView>

--- a/example/components/Movies.tsx
+++ b/example/components/Movies.tsx
@@ -74,7 +74,7 @@ const MovieRow = ({
     isLegend: boolean;
 }) => {
     const movies = playlistData[playlist.id]();
-    const DRAW_DISTANCE_ROW = isLegend ? 500 : 250;
+    const DRAW_DISTANCE_ROW = 500;
     // let opacity = 0;
     // if (isLegend) {
     //     const [_opacity, setOpacity] = useRecyclingState<number>(() => {
@@ -158,7 +158,7 @@ const Movies = ({ isLegend, recycleItems }: { isLegend: boolean; recycleItems?: 
 
     // Flashlist appears to internally multiple the draw distance by 2-3 so increase the draw distance
     // for the Legend version to get the same effect
-    const DRAW_DISTANCE = isLegend ? 500 : 250;
+    const DRAW_DISTANCE = 500;
     console.log("is legend", isLegend, DRAW_DISTANCE);
 
     return (


### PR DESCRIPTION
Congratulations on the launch! I'm excited to see another list library in RN!

I looked at the codebase to understand why FlashList has so much blank area in your video [on x](https://x.com/jmeistrich/status/1915013704154054879).

FlashList's `drawDistance` is set to half of LegendList in all samples based on the assumption that we multiply them; however, we don't. FlashList uses [`ProgressiveListView`](https://github.com/Flipkart/recyclerlistview/blob/master/src/core/ProgressiveListView.tsx) that supports manipulation of drawDistance on initial load. We use that to prepare our recycling pool in advance (by [multiplying](https://github.com/Shopify/flash-list/blob/242ffce982cd0d482b4736ba7b16c854bd831a22/src/FlashList.tsx#L374) by 3). This is useful when item types are different. After the initial mount, the drawDistance used goes back to the [initial](https://github.com/Shopify/flash-list/blob/242ffce982cd0d482b4736ba7b16c854bd831a22/src/FlashList.tsx#L375) value. Since you're manually reducing it to less than default, it's leading to more blank areas. The multiplier doesn't apply to scrolling and we don't process items in pool unless they're needed. We only process visible window and drawDistance worth of items above and below.

We know that drawDistance <250 doesn't work well because scrolling in RN is async. This makes the comparison unfair. Based on LegendList's definition of drawDistance, it makes it exactly the same as FlashList v1, so we should be using the same values. I'm fixing that in this PR. After fixing, here are the new comparison videos (new arch):

### 1x scroll speed (fast scroll, almost no blanks in both):

https://github.com/user-attachments/assets/bf7e0830-4c28-4b05-be5a-8a70dbc2e4e7

### 1.3x scroll speed (faster scroll, both start to show some blanking)

https://github.com/user-attachments/assets/f791a46c-4b5e-4a83-b8ef-d1f2450a6630

In this sample, v1 and Legend seem to perform almost the same, which is great actually, but the claim that it's faster is incorrect.

I've used the following script to scroll; you can reference it to see what 1x and 1.3x translates to: [https://gist.github.com/naqvitalha/8ac4404a65bd314906447541f2e6baf1](https://gist.github.com/naqvitalha/8ac4404a65bd314906447541f2e6baf1)

Also, FlashList's performance improves on RN 0.78; not sure if it's true for LegendList. There was a lot of layout happening that was unnecessary, and Meta has fixed that in RN 0.78. I would highly recommend comparing on newer versions. 

I look forward to seeing how LegendList evolves. Keep up the great work!