### PR TITLE
Add missing react import to ListHeaderComponentContainer

### DIFF
--- a/src/ListHeaderComponentContainer.tsx
+++ b/src/ListHeaderComponentContainer.tsx
@@ -1,3 +1,5 @@
+// biome-ignore lint/style/useImportType: <explanation>
+import * as React from "react";
 import { Animated, type StyleProp, type ViewStyle } from "react-native";
 import { type StateContext, set$ } from "./state";
 import { useValue$ } from "./useValue$";


### PR DESCRIPTION
The new `ListHeaderComponentContainer` is missing the React import, resulting in:

![IMG_BA49D7ED5F59-1](https://github.com/user-attachments/assets/cef211ce-54c1-48a0-92ec-5b0ae65ebc39)

in some envs.