### PR TITLE
fix: AnimatedLegendList ref type

### DIFF
--- a/src/reanimated.tsx
+++ b/src/reanimated.tsx
@@ -39,11 +39,11 @@ const LegendListForwardedRef = React.forwardRef(function LegendListForwardedRef<
 
 const AnimatedLegendListComponent = Animated.createAnimatedComponent(LegendListForwardedRef);
 
-type AnimatedLegendListProps<ItemT> = Omit<AnimatedLegendListPropsBase<ItemT>, "refLegendList"> &
+type AnimatedLegendListProps<ItemT> = Omit<AnimatedLegendListPropsBase<ItemT>, "refLegendList" | "ref"> &
     OtherAnimatedLegendListProps<ItemT>;
 
 type AnimatedLegendListDefinition = <ItemT>(
-    props: Omit<AnimatedLegendListPropsBase<ItemT>, "refLegendList"> &
+    props: Omit<AnimatedLegendListPropsBase<ItemT>, "refLegendList" | "ref"> &
         OtherAnimatedLegendListProps<ItemT> & { ref?: React.Ref<LegendListRef> },
 ) => React.ReactElement | null;
 


### PR DESCRIPTION
The ref type from AnimatedScrollView is not omitted so that it breaks the type of ref on AnimatedLegendList.

Example to see the type error:
```jsx
import { type LegendListRef } from '@legendapp/list';
import { AnimatedLegendList } from "@legendapp/list/reanimated";

const App = () => {
...

const legendListRef = useRef<LegendListRef>(null);

return (
  <AnimatedLegendList
    ref={legendListRef} // this will show a type error
  />
)

```

This is an example of the type error:
```
Type 'RefObject<LegendListRef>' is not assignable to type '((string | ((instance: AnimatedScrollView | null) => void) | RefObject<AnimatedScrollView>) & (RefObject<LegendListRef> | ((instance: LegendListRef | null) => void))) | null | undefined'.
  Type 'RefObject<LegendListRef>' is not assignable to type 'RefObject<AnimatedScrollView> & ((instance: LegendListRef | null) => void)'.
    Type 'RefObject<LegendListRef>' is not assignable to type 'RefObject<AnimatedScrollView>'.
      Type 'LegendListRef' is not assignable to type 'AnimatedScrollView'.
```