### PR TITLE
fix: PaddingAndAdjust for ListHeaderComponent

### DIFF
--- a/src/LegendList.tsx
+++ b/src/LegendList.tsx
@@ -1008,7 +1008,12 @@ const LegendListInner = typedForwardRef(function LegendListInner<T>(
 
     const updateAlignItemsPaddingTop = () => {
         if (alignItemsAtEnd) {
-            const { scrollLength } = refState.current!;
+            const state = refState.current!;
+            if(!state.data || state.data.length === 0) {
+                setPaddingTop({ alignItemsPaddingTop: 0 });
+                return;
+            }
+            const {scrollLength} = state;
             const contentSize = getContentSize(ctx);
             const paddingTop = Math.max(0, Math.floor(scrollLength - contentSize));
             setPaddingTop({ alignItemsPaddingTop: paddingTop });

--- a/src/ListComponent.tsx
+++ b/src/ListComponent.tsx
@@ -164,7 +164,7 @@ export const ListComponent = typedMemo(function ListComponent<ItemT>({
             }
             ref={refScrollView as any}
         >
-            {!ListEmptyComponent && (ENABLE_DEVMODE ? <PaddingAndAdjustDevMode /> : <PaddingAndAdjust />)}
+            {ENABLE_DEVMODE ? <PaddingAndAdjustDevMode /> : <PaddingAndAdjust />}
             {ListHeaderComponent && (
                 <ListHeaderComponentContainer
                     style={ListHeaderComponentStyle}


### PR DESCRIPTION
Fixes #249 
LegendList removes paddingTop from style and stores the value in state. Then this padding is reapplied with PaddingAndAdjust component, which is rendered only if ListEmptyComponent is not provided. This PR fixes that and aligns with the behavior from the past -> https://github.com/LegendApp/legend-list/blob/c4de5253b3e5bfba37810ad04cebea403e0c00d5/src/ListComponent.tsx#L181

EDIT: It seems that this extra check was introduced to fix alignItemsAtEnd pushing ListEmptyComponent off the bottom. Instead I modified updateAlignItemsPaddingTop to ignore alignItemsAtEnd when the list is empty.