### PR TITLE
Scrolling to last item ignores footerHeight and listSeparatorSize

### DIFF
--- a/src/LegendList.tsx
+++ b/src/LegendList.tsx
@@ -323,7 +323,7 @@ const LegendListInner = typedForwardRef(function LegendListInner<T>(
         index,
         viewOffset = 0,
         animated = true,
-        viewPosition = 0,
+        viewPosition,
     }: Parameters<LegendListRef["scrollToIndex"]>[0]) => {
         const state = refState.current!;
         if (index >= state.data.length) {
@@ -362,7 +362,7 @@ const LegendListInner = typedForwardRef(function LegendListInner<T>(
 
         // Disable scroll adjust while scrolling so that it doesn't do extra work affecting the target offset
         // Do the scroll
-        scrollTo({ offset: firstIndexScrollPostion, animated, index, viewPosition, viewOffset });
+        scrollTo({ offset: firstIndexScrollPostion, animated, index, viewPosition: viewPosition ?? 0, viewOffset });
     };
 
     const setDidLayout = () => {


### PR DESCRIPTION
# Issue

When scrolling through the list `footerHeight` and `listSeparatorSize` props are respected, however, when we focus the last element they are ignored.

From my analysis it is caused by the fact that we are passing `viewPosition` with the value of 1 into `scrollTo` function. This value is set in [this line](https://github.com/LegendApp/legend-list/blame/e2ba1b39a762a1ad28763a7f5c3351efcdd07e57/src/LegendList.tsx#L338).
However, in this scope `viewPosition` is never undefined, as we give it an default value of 0, and this `if` clause will run for every last item.

## Video

https://github.com/user-attachments/assets/d0208feb-e50d-486d-ab0b-06ac43dd267a

