### PR TITLE
fix: remove non-existent import on web

### DIFF
--- a/src/platform/batchedUpdates.ts
+++ b/src/platform/batchedUpdates.ts
@@ -1,5 +1,3 @@
-import { unstable_batchedUpdates } from "react-native";
-
-const batchedUpdates = unstable_batchedUpdates || ((callback: () => void) => callback());
+const batchedUpdates = ((callback: () => void) => callback());
 
 export { batchedUpdates };


### PR DESCRIPTION
the previous fix was still broken when using Vite, as it still tried to import the function. hopefully this shouldn't change anything functionality-wise