### PR TITLE
chore: improve docs for renderScrollComponent

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -274,6 +274,7 @@ interface LegendListSpecificProps<ItemT, TItemType extends string | undefined> {
 
     /**
      * Render custom ScrollView component.
+     * Note: When using `stickyHeaderIndices`, you must provide an Animated ScrollView component.
      * @default (props) => <ScrollView {...props} />
      */
     renderScrollComponent?: (props: ScrollViewProps) => React.ReactElement<ScrollViewProps>;


### PR DESCRIPTION
While investigating #344, I found that the crash occurs because `stickyHeaderIndices` requires the list component to be wrapped with `Animated.createAnimatedComponent()`.

I explored several approaches to automatically detect if a component is already animated:
1. Checking prototype methods and display names - doesn't work reliably when components are wrapped in user code
2. Runtime instance checks - too fragile and won't work across all wrapping scenarios

Since there's no reliable way to detect animated components, I've updated the `stickyHeaderIndices` property JSDoc to clarify that users need to pass an animated list component when using this feature.

Fixes #344