### PR TITLE
fix: allocating containers for sticky headers not working on first render

### DIFF
--- a/src/utils/findAvailableContainers.ts
+++ b/src/utils/findAvailableContainers.ts
@@ -50,7 +50,7 @@ export function findAvailableContainers(
             const key = peek$(ctx, `containerItemKey${containerIndex}`);
             const isPendingRemoval = pendingRemovalSet.has(containerIndex);
 
-            if ((key === undefined || isPendingRemoval) && canReuseContainer(containerIndex, requiredType)) {
+            if ((key === undefined || isPendingRemoval) && canReuseContainer(containerIndex, requiredType) && !result.includes(containerIndex)) {
                 result.push(containerIndex);
                 if (isPendingRemoval && pendingRemovalSet.delete(containerIndex)) {
                     pendingRemovalChanged = true;


### PR DESCRIPTION
When allocating containers for multiple sticky items, the same container index can be selected repeatedly from stickyContainerPool, resulting in duplicate entries like [0,1,2,3,4,5,6,7,14,14,14,14,14].

**Without the fix**

https://github.com/user-attachments/assets/6346a92e-c84e-48b4-8a01-0964e38820a7

**With the fix**

https://github.com/user-attachments/assets/6e1ec925-35ae-40db-9c2d-53a1615001d2


