### PR TITLE
fix: use globalThis instead of global to avoid next.js crash

### DIFF
--- a/example/app/(tabs)/index.tsx
+++ b/example/app/(tabs)/index.tsx
@@ -9,7 +9,7 @@ import { ThemedText } from "~/components/ThemedText";
 import { ThemedView } from "~/components/ThemedView";
 
 // @ts-expect-error nativeFabricUIManager is not defined in the global object types
-export const IsNewArchitecture = global.nativeFabricUIManager != null;
+export const IsNewArchitecture = globalThis.nativeFabricUIManager != null;
 
 type ListElement = {
     id: number;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -8,4 +8,4 @@ export const ENABLE_DEVMODE = __DEV__ && false;
 export const ENABLE_DEBUG_VIEW = __DEV__ && false;
 
 // @ts-expect-error nativeFabricUIManager is not defined in the global object types
-export const IsNewArchitecture = global.nativeFabricUIManager != null;
+export const IsNewArchitecture = globalThis.nativeFabricUIManager != null;


### PR DESCRIPTION
### Changes

- use globalThis instead of global to avoid crash in next.js