### PR TITLE
fix: update top position of newly created containers

### DIFF
--- a/src/core/calculateItemsInView.ts
+++ b/src/core/calculateItemsInView.ts
@@ -375,7 +375,7 @@ export function calculateItemsInView(
                     : undefined;
         }
 
-        const numContainers = peek$(ctx, "numContainers");
+        let numContainers = prevNumContainers;
         // Reset containers that aren't used anymore because the data has changed
         const pendingRemoval: number[] = [];
         if (dataChanged) {
@@ -389,7 +389,6 @@ export function calculateItemsInView(
 
         // Place newly added items into containers
         if (startBuffered !== null && endBuffered !== null) {
-            let numContainers = prevNumContainers;
             const needNewContainers: number[] = [];
 
             for (let i = startBuffered!; i <= endBuffered; i++) {


### PR DESCRIPTION
Fixes #325

While creating new containers the `numContainers` variable was updated if the newly created containerIndex was larger than `numContainers` https://github.com/LegendApp/legend-list/blob/3c13779a1ad167f965501318379b966b927bc936/src/core/calculateItemsInView.ts#L484-L486

However due to the shadowing of `numContainers`, this update did not affect the loop updating top positions for all containers and it instead used the initial value of `numContainers` for when `calculateItemsInView` was called https://github.com/LegendApp/legend-list/blob/3c13779a1ad167f965501318379b966b927bc936/src/core/calculateItemsInView.ts#L504-L505

This made it so the position was not set for newly added containers, causing them to not render until `calculateItemsInView` was called again for any reason (rerender, scroll event)

I'm sorry I don't have a minimal repo for this or no updated tests. I've been debugging this in our app so never created a minimal repo. A test could be written but I didn't find a good existing test to copy as a base. So I think it will be quicker for you to add a relevant test than via reviews guide me through the relevant mocking

The patch working in our app:
https://github.com/user-attachments/assets/939ac5cc-cb47-4049-bc0b-e38fe2272509

https://github.com/user-attachments/assets/f2c3eff8-1e4c-4299-8aba-c7b096b48b85

Here, everything below the top carousel got a higher containerIndex than `numContainers` from the skeleton render and thus required a scroll event before showing.