### PR TITLE
fix: ignore spurious keyboard events in KeyboardAvoidingLegendList

### DIFF
--- a/src/integrations/keyboard.tsx
+++ b/src/integrations/keyboard.tsx
@@ -48,6 +48,8 @@ export const KeyboardAvoidingLegendList = (forwardRef as TypedForwardRef)(functi
     const keyboardHeight = useSharedValue(0);
     const isOpening = useSharedValue(false);
     const didInteractive = useSharedValue(false);
+    // Track keyboard open state to ignore spurious iOS keyboard events
+    const isKeyboardOpen = useSharedValue(false);
 
     const scrollHandler = useAnimatedScrollHandler(
         (event) => {
@@ -72,6 +74,11 @@ export const KeyboardAvoidingLegendList = (forwardRef as TypedForwardRef)(functi
         {
             onStart: (event) => {
                 "worklet";
+
+                // Ignore spurious events when keyboard is already open
+                if (isKeyboardOpen.get() && event.progress === 1 && event.height > 0) {
+                    return;
+                }
 
                 if (!didInteractive.get()) {
                     if (event.height > 0) {
@@ -138,6 +145,8 @@ export const KeyboardAvoidingLegendList = (forwardRef as TypedForwardRef)(functi
                 }
 
                 didInteractive.set(false);
+
+                isKeyboardOpen.set(event.height > 0);
 
                 if (!horizontal) {
                     keyboardInset.value = Math.max(0, event.height - safeAreaInsetBottom);


### PR DESCRIPTION
Fixes https://github.com/LegendApp/legend-list/issues/369 

## Summary
Adds an `isKeyboardOpen` guard to prevent spurious iOS keyboard events from triggering duplicate scroll adjustments.

## Changes
- Added `isKeyboardOpen` shared value to track keyboard state
- Added early return in `onStart` when keyboard is already open and receives a no-op event (`progress === 1`)
- Set `isKeyboardOpen` in `onEnd` based on final keyboard height

## Root Cause
iOS fires extra keyboard events when the autocomplete bar activates on first keystroke. These events have `progress: 1` (already complete) but still trigger the scroll offset logic since `didInteractive` has been reset by the previous `onEnd`.