### PR TITLE
fix: use empty object if no animatedProps are passed

### DIFF
--- a/src/integrations/reanimated.tsx
+++ b/src/integrations/reanimated.tsx
@@ -68,24 +68,21 @@ const AnimatedLegendList = typedMemo(
         props: AnimatedLegendListProps<ItemT>,
         ref: React.Ref<LegendListRef>,
     ) {
-        const { refScrollView, animatedProps, ...rest } = props as AnimatedLegendListProps<ItemT>;
+        const { refScrollView, ...rest } = props as AnimatedLegendListProps<ItemT>;
+        const { animatedProps } = props;
 
         const refLegendList = React.useRef<LegendListRef | null>(null);
 
         const combinedRef = useCombinedRef(refLegendList, ref);
 
-        const propsToPass: Record<string, unknown> = {
-            ref: refScrollView,
-            refLegendList: combinedRef,
-            ...(rest as Record<string, unknown>),
-        };
-
-        if (animatedProps !== undefined) {
-            propsToPass.animatedProps = animatedProps;
-            propsToPass.animatedPropsInternal = animatedProps;
-        }
-
-        return <AnimatedLegendListComponent {...propsToPass} />;
+        return (
+            <AnimatedLegendListComponent
+                animatedPropsInternal={animatedProps}
+                ref={refScrollView}
+                refLegendList={combinedRef}
+                {...(rest as any)}
+            />
+        );
     }),
 ) as AnimatedLegendListDefinition;
 


### PR DESCRIPTION
For some reason the `animatedProps` are `undefined` on the first render causing a crash. The PR title might not be accurate since I do not know what causes the `animatedProps` to be undefined but they should be optional, right?

Using reanimated@3.19.4 and legend-list@3.0.0-beta.11

Default to `{}` to avoid the crash. 


<img width="1320" height="2868" alt="Simulator Screenshot - iPhone 17 Pro Max - 2025-12-17 at 08 26 45" src="https://github.com/user-attachments/assets/522c198e-1b25-4bbb-9653-7fd49a1a4daf" />

