### PR TITLE
calculateItemsInView - Don't return early if sticky index changed

### DIFF
--- a/__tests__/core/calculateItemsInView.test.ts
+++ b/__tests__/core/calculateItemsInView.test.ts
@@ -1143,6 +1143,27 @@ describe("calculateItemsInView", () => {
             });
         });
 
+        it("should call onStickyHeaderChange when the active sticky index changes inside the cached scroll range", () => {
+            const onStickyHeaderChange = mock();
+            setupStickyScenario();
+            mockState.props.onStickyHeaderChange = onStickyHeaderChange;
+            mockState.props.drawDistance = 50;
+            mockState.scrollForNextCalculateItemsInView = {
+                bottom: 2000,
+                top: -1000,
+            };
+            mockCtx.values.set("activeStickyIndex", 0);
+            mockState.scroll = 150; // Should activate sticky index 1
+
+            calculateItemsInView(mockCtx);
+
+            expect(onStickyHeaderChange).toHaveBeenCalledTimes(1);
+            expect(onStickyHeaderChange).toHaveBeenCalledWith({
+                index: 1,
+                item: mockState.props.data[1],
+            });
+        });
+
         it("should not call onStickyHeaderChange when the sticky index remains the same", () => {
             const onStickyHeaderChange = mock();
             setupStickyScenario();

--- a/__tests__/core/calculateItemsInView.test.ts
+++ b/__tests__/core/calculateItemsInView.test.ts
@@ -1152,6 +1152,7 @@ describe("calculateItemsInView", () => {
                 bottom: 2000,
                 top: -1000,
             };
+            mockState.idsInView = ["cached"];
             mockCtx.values.set("activeStickyIndex", 0);
             mockState.scroll = 150; // Should activate sticky index 1
 
@@ -1162,6 +1163,7 @@ describe("calculateItemsInView", () => {
                 index: 1,
                 item: mockState.props.data[1],
             });
+            expect(mockState.idsInView).toEqual(["cached"]);
         });
 
         it("should not call onStickyHeaderChange when the sticky index remains the same", () => {

--- a/src/core/calculateItemsInView.ts
+++ b/src/core/calculateItemsInView.ts
@@ -220,6 +220,7 @@ export function calculateItemsInView(
         const currentStickyIdx =
             stickyIndicesArr.length > 0 ? findCurrentStickyIndex(stickyIndicesArr, scroll, state) : -1;
         const nextActiveStickyIndex = currentStickyIdx >= 0 ? stickyIndicesArr[currentStickyIdx] : -1;
+        const stickyIndexDidChange = previousStickyIndex !== nextActiveStickyIndex;
         if (currentStickyIdx >= 0 || previousStickyIndex >= 0) {
             set$(ctx, "activeStickyIndex", nextActiveStickyIndex);
         }
@@ -248,6 +249,7 @@ export function calculateItemsInView(
             !suppressInitialScrollSideEffects &&
             !dataChanged &&
             !forceFullItemPositions &&
+            !stickyIndexDidChange &&
             scrollForNextCalculateItemsInView
         ) {
             const { top, bottom } = scrollForNextCalculateItemsInView;

--- a/src/core/calculateItemsInView.ts
+++ b/src/core/calculateItemsInView.ts
@@ -224,6 +224,16 @@ export function calculateItemsInView(
         if (currentStickyIdx >= 0 || previousStickyIndex >= 0) {
             set$(ctx, "activeStickyIndex", nextActiveStickyIndex);
         }
+        const shouldNotifyStickyHeaderChange =
+            !!onStickyHeaderChange && stickyIndicesArr.length > 0 && stickyIndexDidChange;
+        const finishCalculateItemsInView = shouldNotifyStickyHeaderChange
+            ? () => {
+                  const item = data[nextActiveStickyIndex];
+                  if (item !== undefined) {
+                      onStickyHeaderChange?.({ index: nextActiveStickyIndex, item });
+                  }
+              }
+            : undefined;
 
         let scrollBufferTop = drawDistance;
         let scrollBufferBottom = drawDistance;
@@ -249,7 +259,6 @@ export function calculateItemsInView(
             !suppressInitialScrollSideEffects &&
             !dataChanged &&
             !forceFullItemPositions &&
-            !stickyIndexDidChange &&
             scrollForNextCalculateItemsInView
         ) {
             const { top, bottom } = scrollForNextCalculateItemsInView;
@@ -261,6 +270,7 @@ export function calculateItemsInView(
             ) {
                 // On web, MVCP anchor lock still needs a pass even inside the cached range window.
                 if (Platform.OS !== "web" || !isInMVCPActiveMode(state)) {
+                    finishCalculateItemsInView?.();
                     return;
                 }
             }
@@ -696,16 +706,6 @@ export function calculateItemsInView(
             }
         }
 
-        if (
-            onStickyHeaderChange &&
-            stickyIndicesArr.length > 0 &&
-            nextActiveStickyIndex !== undefined &&
-            nextActiveStickyIndex !== previousStickyIndex
-        ) {
-            const item = data[nextActiveStickyIndex];
-            if (item !== undefined) {
-                onStickyHeaderChange({ index: nextActiveStickyIndex, item });
-            }
-        }
+        finishCalculateItemsInView?.();
     });
 }


### PR DESCRIPTION
I noticed `onStickyHeaderChange` was not being called when scrolling slowly or just sometimes not at all.

The early return optimization check wasn't taking the sticky header index change into consideration so the check to make the call back to `onStickyHeaderChange` was never hit.