### PR TITLE
fix: Clear stale size caches on data change

### DIFF
--- a/src/core/calculateItemsInView.ts
+++ b/src/core/calculateItemsInView.ts
@@ -264,6 +264,16 @@ export function calculateItemsInView(
             indexByKey.clear();
             idCache.length = 0;
             positions.clear();
+            const { sizesKnown } = state;
+            const staleKeys = new Set([...sizesKnown.keys(), ...sizes.keys()]);
+            for (let i = 0; i < data.length; i++) {
+                const id = keyExtractor ? keyExtractor(data[i], i) : String(i);
+                staleKeys.delete(id);
+            }
+            for (const key of staleKeys) {
+                sizesKnown.delete(key);
+                sizes.delete(key);
+            }
         }
 
         // Update all positions upfront so we can assume they're correct

--- a/src/core/calculateItemsInView.ts
+++ b/src/core/calculateItemsInView.ts
@@ -267,7 +267,8 @@ export function calculateItemsInView(
             const { sizesKnown } = state;
             const staleKeys = new Set([...sizesKnown.keys(), ...sizes.keys()]);
             for (let i = 0; i < data.length; i++) {
-                const id = keyExtractor ? keyExtractor(data[i], i) : String(i);
+                const id = keyExtractor ? keyExtractor(data[i], i) : i;
+                // @ts-expect-error Types will match at runtime
                 staleKeys.delete(id);
             }
             for (const key of staleKeys) {

--- a/src/core/calculateItemsInView.ts
+++ b/src/core/calculateItemsInView.ts
@@ -267,8 +267,7 @@ export function calculateItemsInView(
             const { sizesKnown } = state;
             const staleKeys = new Set([...sizesKnown.keys(), ...sizes.keys()]);
             for (let i = 0; i < data.length; i++) {
-                const id = keyExtractor ? keyExtractor(data[i], i) : i;
-                // @ts-expect-error Types will match at runtime
+                const id = getId(state, i);
                 staleKeys.delete(id);
             }
             for (const key of staleKeys) {


### PR DESCRIPTION
First off thanks for all the work on the library, v3 is looking great 🚀

While testing the beta in our app I ran into blanking behaviour in a paginated list where data can shrink and grow again with items that contain the same keys. By simply clearing the size caches for stale keys when data changes I was able to resolve the problem. I'm sure you might have a more elegant solutions but this fixed the issue for me.

_This might not be related to only v3 but just aimed at this branch anyways._

| Before | After |
| --- | --- |
| <video src="https://github.com/user-attachments/assets/a1d9a54f-c69b-4160-802e-cab4b5d3e426" /> | <video src="https://github.com/user-attachments/assets/28774023-9e93-4d3f-b5d3-1272668154d6" /> |