### PR TITLE
Fix style prop of KeyboardAvoidingLegendList on Non-android platforms.

### DIFF
--- a/src/integrations/keyboard.tsx
+++ b/src/integrations/keyboard.tsx
@@ -222,7 +222,7 @@ export const KeyboardAvoidingLegendList = (forwardRef as TypedForwardRef)(functi
               }),
               [styleProp, keyboardInset],
           )
-        : undefined;
+        : styleProp;
 
     return (
         <AnimatedLegendList


### PR DESCRIPTION
On Non-android, you can't pass a `style` prop to KeyboardAvoidingLegendList.