### PR TITLE
[v3] Fix horizontal list dynamic heights

### DIFF
--- a/__tests__/__mocks__/createMockState.ts
+++ b/__tests__/__mocks__/createMockState.ts
@@ -42,7 +42,6 @@ export function createMockState(
         minIndexSizeChanged: undefined,
         nativeContentInset: undefined,
         nativeMarginTop: 0,
-        needsOtherAxisSize: false,
         otherAxisSize: undefined,
         positions: new Map(),
         queuedCalculateItemsInView: undefined,

--- a/src/core/handleLayout.ts
+++ b/src/core/handleLayout.ts
@@ -54,12 +54,6 @@ export function handleLayout(ctx: StateContext, layout: LayoutRectangle, setCanR
         }
         checkThresholds(ctx);
 
-        if (state) {
-            // If otherAxisSize minus padding is less than 10, we need to set the size of the other axis
-            // from the item height. 10 is just a magic number to account for border/outline or rounding errors.
-            state.needsOtherAxisSize = otherAxisSize - (state.props.stylePaddingTop || 0) < 10;
-        }
-
         if (IS_DEV && measuredLength === 0) {
             warnDevOnce(
                 "height0",

--- a/src/core/updateItemSize.ts
+++ b/src/core/updateItemSize.ts
@@ -74,7 +74,6 @@ export function updateItemSize(ctx: StateContext, itemKey: string, sizeObj: { wi
     let needsRecalculate = !didContainersLayout;
     let shouldMaintainScrollAtEnd = false;
     let minIndexSizeChanged: number | undefined;
-    let maxOtherAxisSize = peek$(ctx, "otherAxisSize") || 0;
 
     const prevSizeKnown = state.sizesKnown.get(itemKey);
 
@@ -89,12 +88,6 @@ export function updateItemSize(ctx: StateContext, itemKey: string, sizeObj: { wi
         needsRecalculate ||= index >= startBuffered && index <= endBuffered;
         if (!needsRecalculate && state.containerItemKeys.has(itemKey)) {
             needsRecalculate = true;
-        }
-
-        // Handle other axis size
-        if (state.needsOtherAxisSize) {
-            const otherAxisSize = horizontal ? sizeObj.height : sizeObj.width;
-            maxOtherAxisSize = Math.max(maxOtherAxisSize, otherAxisSize);
         }
 
         // Check if we should maintain scroll at end
@@ -133,9 +126,11 @@ export function updateItemSize(ctx: StateContext, itemKey: string, sizeObj: { wi
         }, 1000);
     }
 
+    // Handle other axis size
     const cur = peek$(ctx, "otherAxisSize");
-    if (!cur || maxOtherAxisSize > cur) {
-        set$(ctx, "otherAxisSize", maxOtherAxisSize);
+    const otherAxisSize = horizontal ? sizeObj.height : sizeObj.width;
+    if (!cur || otherAxisSize > cur) {
+        set$(ctx, "otherAxisSize", otherAxisSize);
     }
 
     if (didContainersLayout || checkAllSizesKnown(state)) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -496,7 +496,6 @@ export interface InternalState {
     contentInsetOverride?: Partial<Insets> | null;
     nativeContentInset?: Insets;
     nativeMarginTop: number;
-    needsOtherAxisSize?: boolean;
     otherAxisSize?: number;
     pendingTotalSize?: number;
     positions: Map<string, number>;


### PR DESCRIPTION
I removed the `needsOtherAxisSize` state that caused dynamic height to not be calculated but i didn't remove the tests about it, not sure if i misunderstood the use of this property.