### PR TITLE
fix: guard against undefined `containerPosition` in `fixGaps`

### DIFF
--- a/src/LegendList.tsx
+++ b/src/LegendList.tsx
@@ -597,12 +597,14 @@ const LegendListInner = typedForwardRef(function LegendListInner<T>(
                 const diff = diffs.get(itemKey);
                 if (diff) {
                     const prevPos = peek$(ctx, `containerPosition${i}`);
-                    const newPos = prevPos.top + diff;
-                    if (prevPos.top !== newPos) {
-                        const pos = { ...prevPos };
-                        pos.relativeCoordinate += diff;
-                        pos.top += diff;
-                        set$(ctx, `containerPosition${i}`, pos);
+                    if (prevPos) {
+                        const newPos = prevPos.top + diff;
+                        if (prevPos.top !== newPos) {
+                            const pos = { ...prevPos };
+                            pos.relativeCoordinate += diff;
+                            pos.top += diff;
+                            set$(ctx, `containerPosition${i}`, pos);
+                        }
                     }
                 }
             }


### PR DESCRIPTION
## Problem

On Fabric (new architecture), `fixGaps()` is called from `updateItemSize()` when `IsNewArchitecture` is true. Inside `fixGaps`, `peek$(ctx, containerPosition${i})` can return `undefined` for containers that were created by `findAvailableContainers` but whose position was never initialized (race condition between container creation and position assignment in `calculateItemsInView`).

This causes a crash:
```
TypeError: Cannot read property 'top' of undefined
```

Stack trace from production (Hermes, minified):
```
anonymous@1:3064338
anonymous@1:3072958
doUpdate@1:3055761
onLayout@1:3055697
executeDispatch@1:287021
```

Call chain: `onLayout` → `doUpdate` → `updateItemSize` → `fixGaps` → `prevPos.top` (crash)

## Root Cause

When `findAvailableContainers` creates new container indices (lines around 1640-1654 in compiled output), it sets `containerItemKey` and `containerItemData` via `set$()`, but does NOT set `containerPosition`. If `fixGaps()` runs before `calculateItemsInView` has a chance to initialize `containerPosition`, `peek$` returns `undefined`.

Notably, the same pattern in `calculateItemsInView` already has the guard (line ~1689): `if (!prevPos || ...)`, but `fixGaps` is missing it.

## Fix

Add a null check on `prevPos` before accessing `.top`, consistent with the existing guard in `calculateItemsInView`.

## Environment
- @legendapp/list v1.1.4
- React Native with Fabric (new architecture)
- Hermes engine
- Expo SDK 54
- Samsung Galaxy A52s (Android 14)