### PR TITLE
Add initialHeaderSize prop to avoid overcalculating containers on first render

### DIFF
--- a/src/components/DatasetLayer.tsx
+++ b/src/components/DatasetLayer.tsx
@@ -18,8 +18,8 @@ import { updateItemSize } from "@/core/updateItemSize";
 import { useWrapIfItem } from "@/core/useWrapIfItem";
 import { setupViewability } from "@/core/viewability";
 import { type StateContext, StateProvider, set$, useStateContext } from "@/state/state";
-import type { InternalState, LegendListDatasetsProps, ScrollIndexWithOffset } from "@/types";
-import { typedForwardRef } from "@/types";
+import type { DatasetEntry, InternalState, LegendListDatasetsProps, ScrollIndexWithOffset } from "@/types";
+import { typedForwardRef, typedMemo } from "@/types";
 import { checkAtBottom } from "@/utils/checkAtBottom";
 import { checkAtTop } from "@/utils/checkAtTop";
 import { createColumnWrapperStyle } from "@/utils/createColumnWrapperStyle";
@@ -53,10 +53,13 @@ export interface DatasetLayerHandle {
 }
 
 // Props for the inner headless layer — shared props from LegendListDatasetsProps
-// plus the per-dataset data and the parent scroll ref
+// plus the per-dataset data/dataVersion and the parent scroll ref.
+// Note: dataVersion here is the PER-DATASET version from DatasetEntry, not the
+// shared prop — this prevents a shared bump from rebuilding all datasets at once.
 export type DatasetLayerProps<T> = Omit<
     LegendListDatasetsProps<T>,
     | "datasets"
+    | "dataVersion"
     | "ListHeaderComponent"
     | "ListHeaderComponentStyle"
     | "ListFooterComponent"
@@ -66,6 +69,7 @@ export type DatasetLayerProps<T> = Omit<
     | "style"
 > & {
     data: ReadonlyArray<T>;
+    dataVersion?: DatasetEntry<T>["dataVersion"];
     refScroller: React.RefObject<ScrollView>;
 };
 
@@ -371,16 +375,21 @@ const DatasetLayerInner = typedForwardRef(function DatasetLayerInner<T>(
     );
 });
 
-export const DatasetLayer = typedForwardRef(function DatasetLayer<T>(
-    props: DatasetLayerProps<T> & { active: boolean },
-    ref: ForwardedRef<DatasetLayerHandle>,
-) {
-    const { active, ...rest } = props;
-    return (
-        <StateProvider>
-            <Activity mode={active ? "visible" : "hidden"}>
-                <DatasetLayerInner ref={ref} {...(rest as DatasetLayerProps<T>)} />
-            </Activity>
-        </StateProvider>
-    );
-});
+// Memoized so that when LegendListDatasets re-renders (e.g. because the active
+// dataset's data changed), sibling DatasetLayers whose data and active flag
+// haven't changed are skipped entirely.
+export const DatasetLayer = typedMemo(
+    typedForwardRef(function DatasetLayer<T>(
+        props: DatasetLayerProps<T> & { active: boolean },
+        ref: ForwardedRef<DatasetLayerHandle>,
+    ) {
+        const { active, ...rest } = props;
+        return (
+            <StateProvider>
+                <Activity mode={active ? "visible" : "hidden"}>
+                    <DatasetLayerInner ref={ref} {...(rest as DatasetLayerProps<T>)} />
+                </Activity>
+            </StateProvider>
+        );
+    }),
+);

--- a/src/components/DatasetLayer.tsx
+++ b/src/components/DatasetLayer.tsx
@@ -1,0 +1,342 @@
+// biome-ignore lint/style/useImportType: Leaving this out makes it crash in some environments
+
+import type { ForwardedRef } from "react";
+import * as React from "react";
+import { useCallback, useEffect, useImperativeHandle, useLayoutEffect, useMemo, useRef } from "react";
+import { Dimensions, type LayoutRectangle, type ScrollView } from "react-native";
+
+import { Containers } from "@/components/Containers";
+import { IsNewArchitecture } from "@/constants";
+import { calculateItemsInView } from "@/core/calculateItemsInView";
+import { checkResetContainers } from "@/core/checkResetContainers";
+import { doInitialAllocateContainers } from "@/core/doInitialAllocateContainers";
+import { handleLayout } from "@/core/handleLayout";
+import { ScrollAdjustHandler } from "@/core/ScrollAdjustHandler";
+import { updateItemPositions } from "@/core/updateItemPositions";
+import { updateItemSize } from "@/core/updateItemSize";
+import { useWrapIfItem } from "@/core/useWrapIfItem";
+import { setupViewability } from "@/core/viewability";
+import { StateProvider, set$, useStateContext } from "@/state/state";
+import type { InternalState, LegendListDatasetsProps } from "@/types";
+import { typedForwardRef } from "@/types";
+import { checkAtBottom } from "@/utils/checkAtBottom";
+import { checkAtTop } from "@/utils/checkAtTop";
+import { createColumnWrapperStyle } from "@/utils/createColumnWrapperStyle";
+import { getId } from "@/utils/getId";
+import { getRenderedItem } from "@/utils/getRenderedItem";
+import { setPaddingTop } from "@/utils/setPaddingTop";
+
+const DEFAULT_DRAW_DISTANCE = 250;
+const DEFAULT_ITEM_SIZE = 100;
+
+// React.Activity is stable in React 19 but may not be in @types/react yet
+const Activity = (React as any).Activity as React.ComponentType<{
+    mode: "visible" | "hidden";
+    children: React.ReactNode;
+}>;
+
+export interface DatasetLayerHandle {
+    /** Route a scroll offset to this dataset (only called for active dataset) */
+    onScrollOffset: (offset: number) => void;
+    /** Propagate viewport layout from the parent ScrollView */
+    setViewportLayout: (layout: LayoutRectangle) => void;
+    /** Propagate the shared header size to this dataset's ctx */
+    setHeaderSize: (size: number) => void;
+    /** Called when this dataset switches from inactive → active */
+    activate: (scrollOffset: number) => void;
+}
+
+// Props for the inner headless layer — shared props from LegendListDatasetsProps
+// plus the per-dataset data and the parent scroll ref
+export type DatasetLayerProps<T> = Omit<
+    LegendListDatasetsProps<T>,
+    | "datasets"
+    | "ListHeaderComponent"
+    | "ListHeaderComponentStyle"
+    | "ListFooterComponent"
+    | "ListFooterComponentStyle"
+    | "onLayout"
+    | "refScrollView"
+    | "style"
+> & {
+    data: ReadonlyArray<T>;
+    refScroller: React.RefObject<ScrollView>;
+};
+
+const DatasetLayerInner = typedForwardRef(function DatasetLayerInner<T>(
+    props: DatasetLayerProps<T>,
+    ref: ForwardedRef<DatasetLayerHandle>,
+) {
+    const {
+        alignItemsAtEnd = false,
+        columnWrapperStyle,
+        contentContainerStyle: contentContainerStyleProp,
+        data: dataProp = [],
+        dataVersion,
+        drawDistance = DEFAULT_DRAW_DISTANCE,
+        enableAverages = true,
+        estimatedItemSize: estimatedItemSizeProp,
+        estimatedListSize,
+        extraData,
+        getEstimatedItemSize,
+        getFixedItemSize,
+        getItemType,
+        horizontal,
+        initialContainerPoolRatio = 2,
+        initialHeaderSize,
+        itemsAreEqual,
+        keyExtractor: keyExtractorProp,
+        maintainScrollAtEnd = false,
+        maintainScrollAtEndThreshold = 0.1,
+        maintainVisibleContentPosition = true,
+        numColumns: numColumnsProp = 1,
+        onEndReached,
+        onEndReachedThreshold = 0.5,
+        onItemSizeChanged,
+        onLoad,
+        onStartReached,
+        onStartReachedThreshold = 0.5,
+        onStickyHeaderChange,
+        onViewableItemsChanged,
+        recycleItems = false,
+        refScroller,
+        renderItem,
+        snapToIndices,
+        stickyIndices,
+        suggestEstimatedItemSize,
+        viewabilityConfig,
+        viewabilityConfigCallbackPairs,
+        waitForInitialLayout,
+        stickyHeaderConfig,
+        ItemSeparatorComponent,
+    } = props;
+
+    const ctx = useStateContext();
+    if (initialHeaderSize !== undefined && !ctx.internalState) {
+        ctx.values.set("headerSize", initialHeaderSize);
+    }
+    ctx.columnWrapperStyle =
+        columnWrapperStyle ||
+        (contentContainerStyleProp ? createColumnWrapperStyle(contentContainerStyleProp as any) : undefined);
+
+    const estimatedItemSize = estimatedItemSizeProp ?? DEFAULT_ITEM_SIZE;
+    const scrollBuffer = (drawDistance ?? DEFAULT_DRAW_DISTANCE) || 1;
+    const keyExtractor = keyExtractorProp ?? ((_item: any, index: number) => index.toString());
+
+    const refState = useRef<InternalState>();
+
+    if (!refState.current) {
+        if (!ctx.internalState) {
+            const initialScrollLength = (estimatedListSize ??
+                (IsNewArchitecture ? { height: 0, width: 0 } : Dimensions.get("window")))[
+                horizontal ? "width" : "height"
+            ];
+
+            ctx.internalState = {
+                activeStickyIndex: undefined,
+                averageSizes: {},
+                columns: new Map(),
+                containerItemKeys: new Set(),
+                containerItemTypes: new Map(),
+                dataChangeNeedsScrollUpdate: false,
+                enableScrollForNextCalculateItemsInView: true,
+                endBuffered: -1,
+                endNoBuffer: -1,
+                endReachedBlockedByTimer: false,
+                firstFullyOnScreenIndex: -1,
+                idCache: [],
+                idsInView: [],
+                indexByKey: new Map(),
+                initialScroll: undefined,
+                isAtEnd: false,
+                isAtStart: false,
+                isEndReached: false,
+                isStartReached: false,
+                lastBatchingAction: Date.now(),
+                lastLayout: undefined,
+                loadStartTime: Date.now(),
+                minIndexSizeChanged: 0,
+                nativeMarginTop: 0,
+                positions: new Map(),
+                props: {} as any,
+                queuedCalculateItemsInView: 0,
+                refScroller: undefined as any,
+                scroll: 0,
+                scrollAdjustHandler: new ScrollAdjustHandler(ctx),
+                scrollForNextCalculateItemsInView: undefined,
+                scrollHistory: [],
+                scrollLength: initialScrollLength,
+                scrollPending: 0,
+                scrollPrev: 0,
+                scrollPrevTime: 0,
+                scrollProcessingEnabled: true,
+                scrollTime: 0,
+                sizes: new Map(),
+                sizesKnown: new Map(),
+                startBuffered: -1,
+                startNoBuffer: -1,
+                startReachedBlockedByTimer: false,
+                stickyContainerPool: new Set(),
+                stickyContainers: new Map(),
+                timeoutSizeMessage: 0,
+                timeouts: new Set(),
+                totalSize: 0,
+                viewabilityConfigCallbackPairs: undefined as never,
+            };
+
+            set$(ctx, "maintainVisibleContentPosition", maintainVisibleContentPosition);
+            set$(ctx, "extraData", extraData);
+        }
+        refState.current = ctx.internalState;
+    }
+
+    const state = refState.current!;
+    const isFirst = !state.props.renderItem;
+
+    const didDataChange = state.props.dataVersion !== dataVersion || state.props.data !== dataProp;
+    if (didDataChange) {
+        state.dataChangeNeedsScrollUpdate = true;
+    }
+
+    state.props = {
+        alignItemsAtEnd,
+        data: dataProp,
+        dataVersion,
+        enableAverages,
+        estimatedItemSize,
+        getEstimatedItemSize: useWrapIfItem(getEstimatedItemSize),
+        getFixedItemSize: useWrapIfItem(getFixedItemSize),
+        getItemType: useWrapIfItem(getItemType),
+        horizontal: !!horizontal,
+        initialContainerPoolRatio,
+        initialScroll: undefined,
+        itemsAreEqual,
+        keyExtractor: useWrapIfItem(keyExtractor),
+        maintainScrollAtEnd,
+        maintainScrollAtEndThreshold,
+        maintainVisibleContentPosition,
+        numColumns: numColumnsProp,
+        onEndReached,
+        onEndReachedThreshold,
+        onItemSizeChanged,
+        onLoad,
+        onScroll: undefined,
+        onStartReached,
+        onStartReachedThreshold,
+        onStickyHeaderChange,
+        recycleItems: !!recycleItems,
+        renderItem: renderItem!,
+        scrollBuffer,
+        snapToIndices,
+        stickyIndicesArr: stickyIndices ?? [],
+        stickyIndicesSet: useMemo(() => new Set(stickyIndices ?? []), [stickyIndices?.join(",")]),
+        stylePaddingBottom: 0,
+        stylePaddingTop: 0,
+        suggestEstimatedItemSize: !!suggestEstimatedItemSize,
+    };
+
+    state.refScroller = refScroller;
+
+    const memoizedLastItemKeys = useMemo(() => {
+        if (!dataProp.length) return [];
+        return Array.from({ length: Math.min(numColumnsProp, dataProp.length) }, (_, i) =>
+            getId(state, dataProp.length - 1 - i),
+        );
+    }, [dataProp, dataVersion, numColumnsProp]);
+
+    const initializeStateVars = useCallback(() => {
+        set$(ctx, "lastItemKeys", memoizedLastItemKeys);
+        set$(ctx, "numColumns", numColumnsProp);
+        setPaddingTop(ctx, state, { stylePaddingTop: 0 });
+    }, [memoizedLastItemKeys, numColumnsProp]);
+
+    if (isFirst) {
+        initializeStateVars();
+        updateItemPositions(ctx, state, /*dataChanged*/ true);
+    }
+
+    useLayoutEffect(() => {
+        const didAllocateContainers = dataProp.length > 0 && doInitialAllocateContainers(ctx, state);
+        if (!didAllocateContainers) {
+            checkResetContainers(ctx, state, isFirst, dataProp);
+        }
+    }, [dataProp, dataVersion, numColumnsProp]);
+
+    useLayoutEffect(() => {
+        set$(ctx, "extraData", extraData);
+    }, [extraData]);
+
+    useLayoutEffect(initializeStateVars, [dataVersion, memoizedLastItemKeys.join(","), numColumnsProp]);
+
+    useEffect(() => {
+        const viewability = setupViewability({
+            onViewableItemsChanged,
+            viewabilityConfig,
+            viewabilityConfigCallbackPairs,
+        });
+        state.viewabilityConfigCallbackPairs = viewability;
+        state.enableScrollForNextCalculateItemsInView = !viewability;
+    }, [viewabilityConfig, viewabilityConfigCallbackPairs, onViewableItemsChanged]);
+
+    useImperativeHandle(
+        ref,
+        () => ({
+            activate(scrollOffset: number) {
+                state.scroll = scrollOffset;
+                state.dataChangeNeedsScrollUpdate = true;
+                state.scrollForNextCalculateItemsInView = undefined;
+                calculateItemsInView(ctx, state, { dataChanged: false, doMVCP: false });
+            },
+            onScrollOffset(offset: number) {
+                state.scroll = offset;
+                state.lastBatchingAction = Date.now();
+                state.dataChangeNeedsScrollUpdate = false;
+                calculateItemsInView(ctx, state);
+                checkAtBottom(ctx, state);
+                checkAtTop(state);
+            },
+            setHeaderSize(size: number) {
+                set$(ctx, "headerSize", size);
+            },
+            setViewportLayout(layout: LayoutRectangle) {
+                handleLayout(ctx, state, layout, () => {});
+            },
+        }),
+        [],
+    );
+
+    const fns = useMemo(
+        () => ({
+            getRenderedItem: (key: string) => getRenderedItem(ctx, state, key),
+            updateItemSize: (itemKey: string, sizeObj: { width: number; height: number }) =>
+                updateItemSize(ctx, state, itemKey, sizeObj),
+        }),
+        [],
+    );
+
+    return (
+        <Containers
+            getRenderedItem={fns.getRenderedItem}
+            horizontal={!!horizontal}
+            ItemSeparatorComponent={ItemSeparatorComponent}
+            recycleItems={!!recycleItems}
+            stickyHeaderConfig={stickyHeaderConfig}
+            updateItemSize={fns.updateItemSize}
+            waitForInitialLayout={waitForInitialLayout}
+        />
+    );
+});
+
+export const DatasetLayer = typedForwardRef(function DatasetLayer<T>(
+    props: DatasetLayerProps<T> & { active: boolean },
+    ref: ForwardedRef<DatasetLayerHandle>,
+) {
+    const { active, ...rest } = props;
+    return (
+        <StateProvider>
+            <Activity mode={active ? "visible" : "hidden"}>
+                <DatasetLayerInner ref={ref} {...(rest as DatasetLayerProps<T>)} />
+            </Activity>
+        </StateProvider>
+    );
+});

--- a/src/components/DatasetLayer.tsx
+++ b/src/components/DatasetLayer.tsx
@@ -12,12 +12,13 @@ import { checkResetContainers } from "@/core/checkResetContainers";
 import { doInitialAllocateContainers } from "@/core/doInitialAllocateContainers";
 import { handleLayout } from "@/core/handleLayout";
 import { ScrollAdjustHandler } from "@/core/ScrollAdjustHandler";
+import { scrollToIndex } from "@/core/scrollToIndex";
 import { updateItemPositions } from "@/core/updateItemPositions";
 import { updateItemSize } from "@/core/updateItemSize";
 import { useWrapIfItem } from "@/core/useWrapIfItem";
 import { setupViewability } from "@/core/viewability";
-import { StateProvider, set$, useStateContext } from "@/state/state";
-import type { InternalState, LegendListDatasetsProps } from "@/types";
+import { type StateContext, StateProvider, set$, useStateContext } from "@/state/state";
+import type { InternalState, LegendListDatasetsProps, ScrollIndexWithOffset } from "@/types";
 import { typedForwardRef } from "@/types";
 import { checkAtBottom } from "@/utils/checkAtBottom";
 import { checkAtTop } from "@/utils/checkAtTop";
@@ -25,6 +26,7 @@ import { createColumnWrapperStyle } from "@/utils/createColumnWrapperStyle";
 import { getId } from "@/utils/getId";
 import { getRenderedItem } from "@/utils/getRenderedItem";
 import { setPaddingTop } from "@/utils/setPaddingTop";
+import { updateSnapToOffsets } from "@/utils/updateSnapToOffsets";
 
 const DEFAULT_DRAW_DISTANCE = 250;
 const DEFAULT_ITEM_SIZE = 100;
@@ -44,6 +46,10 @@ export interface DatasetLayerHandle {
     setHeaderSize: (size: number) => void;
     /** Called when this dataset switches from inactive → active */
     activate: (scrollOffset: number) => void;
+    /** Access to the StateContext for ref delegation */
+    getCtx: () => StateContext;
+    /** Access to the InternalState for ref delegation */
+    getState: () => InternalState;
 }
 
 // Props for the inner headless layer — shared props from LegendListDatasetsProps
@@ -84,6 +90,8 @@ const DatasetLayerInner = typedForwardRef(function DatasetLayerInner<T>(
         horizontal,
         initialContainerPoolRatio = 2,
         initialHeaderSize,
+        initialScrollIndex: initialScrollIndexProp,
+        initialScrollOffset: initialScrollOffsetProp,
         itemsAreEqual,
         keyExtractor: keyExtractorProp,
         maintainScrollAtEnd = false,
@@ -110,6 +118,17 @@ const DatasetLayerInner = typedForwardRef(function DatasetLayerInner<T>(
         stickyHeaderConfig,
         ItemSeparatorComponent,
     } = props;
+
+    // Build initialScroll the same way LegendListInner does
+    const initialScroll: ScrollIndexWithOffset | undefined =
+        initialScrollIndexProp || initialScrollOffsetProp
+            ? typeof initialScrollIndexProp === "object"
+                ? { index: initialScrollIndexProp.index || 0, viewOffset: initialScrollIndexProp.viewOffset || 0 }
+                : { index: initialScrollIndexProp || 0, viewOffset: initialScrollOffsetProp || 0 }
+            : undefined;
+
+    // Track whether we've applied the initial scroll for this dataset
+    const hasAppliedInitialScrollRef = useRef(false);
 
     const ctx = useStateContext();
     if (initialHeaderSize !== undefined && !ctx.internalState) {
@@ -147,7 +166,7 @@ const DatasetLayerInner = typedForwardRef(function DatasetLayerInner<T>(
                 idCache: [],
                 idsInView: [],
                 indexByKey: new Map(),
-                initialScroll: undefined,
+                initialScroll,
                 isAtEnd: false,
                 isAtStart: false,
                 isEndReached: false,
@@ -198,6 +217,9 @@ const DatasetLayerInner = typedForwardRef(function DatasetLayerInner<T>(
         state.dataChangeNeedsScrollUpdate = true;
     }
 
+    // Keep initialScroll in sync with props so calculateItemsInView uses it correctly
+    state.initialScroll = initialScroll;
+
     state.props = {
         alignItemsAtEnd,
         data: dataProp,
@@ -209,7 +231,7 @@ const DatasetLayerInner = typedForwardRef(function DatasetLayerInner<T>(
         getItemType: useWrapIfItem(getItemType),
         horizontal: !!horizontal,
         initialContainerPoolRatio,
-        initialScroll: undefined,
+        initialScroll,
         itemsAreEqual,
         keyExtractor: useWrapIfItem(keyExtractor),
         maintainScrollAtEnd,
@@ -263,6 +285,12 @@ const DatasetLayerInner = typedForwardRef(function DatasetLayerInner<T>(
     }, [dataProp, dataVersion, numColumnsProp]);
 
     useLayoutEffect(() => {
+        if (snapToIndices) {
+            updateSnapToOffsets(ctx, state);
+        }
+    }, [snapToIndices]);
+
+    useLayoutEffect(() => {
         set$(ctx, "extraData", extraData);
     }, [extraData]);
 
@@ -282,10 +310,26 @@ const DatasetLayerInner = typedForwardRef(function DatasetLayerInner<T>(
         ref,
         () => ({
             activate(scrollOffset: number) {
-                state.scroll = scrollOffset;
+                // Apply initialScroll the first time this dataset becomes active
+                if (initialScroll && !hasAppliedInitialScrollRef.current) {
+                    hasAppliedInitialScrollRef.current = true;
+                    scrollToIndex(ctx, state, {
+                        animated: false,
+                        index: initialScroll.index,
+                        viewOffset: initialScroll.viewOffset,
+                    });
+                } else {
+                    state.scroll = scrollOffset;
+                }
                 state.dataChangeNeedsScrollUpdate = true;
                 state.scrollForNextCalculateItemsInView = undefined;
                 calculateItemsInView(ctx, state, { dataChanged: false, doMVCP: false });
+            },
+            getCtx() {
+                return ctx;
+            },
+            getState() {
+                return state;
             },
             onScrollOffset(offset: number) {
                 state.scroll = offset;

--- a/src/components/LegendList.tsx
+++ b/src/components/LegendList.tsx
@@ -117,6 +117,7 @@ const LegendListInner = typedForwardRef(function LegendListInner<T>(
         getItemType,
         horizontal,
         initialContainerPoolRatio = 2,
+        initialHeaderSize,
         initialScrollIndex: initialScrollIndexProp,
         initialScrollOffset: initialScrollOffsetProp,
         itemsAreEqual,
@@ -174,6 +175,9 @@ const LegendListInner = typedForwardRef(function LegendListInner<T>(
     const stylePaddingBottomState = extractPadding(style, contentContainerStyle, "Bottom");
 
     const ctx = useStateContext();
+    if (initialHeaderSize !== undefined && !ctx.internalState) {
+        ctx.values.set("headerSize", initialHeaderSize);
+    }
     ctx.columnWrapperStyle =
         columnWrapperStyle || (contentContainerStyle ? createColumnWrapperStyle(contentContainerStyle) : undefined);
 

--- a/src/components/LegendListDatasets.tsx
+++ b/src/components/LegendListDatasets.tsx
@@ -1,0 +1,305 @@
+// biome-ignore lint/style/useImportType: Leaving this out makes it crash in some environments
+import * as React from "react";
+import type { ForwardedRef } from "react";
+import { useCallback, useLayoutEffect, useMemo, useRef } from "react";
+import {
+    Animated,
+    type LayoutRectangle,
+    type NativeScrollEvent,
+    type NativeSyntheticEvent,
+    Platform,
+    RefreshControl,
+    type ScrollView,
+    StyleSheet,
+    View,
+} from "react-native";
+
+import { DatasetLayer, type DatasetLayerHandle } from "@/components/DatasetLayer";
+import { LayoutView } from "@/components/LayoutView";
+import { useCombinedRef } from "@/hooks/useCombinedRef";
+import { useOnLayoutSync } from "@/hooks/useOnLayoutSync";
+import type { LegendListDatasetsProps, LegendListRef } from "@/types";
+import { typedForwardRef, typedMemo } from "@/types";
+import { getComponent } from "@/utils/getComponent";
+
+// Style applied to wrapper of each inactive dataset layer so it takes no layout space
+// and its contents (items at translateY: -9999) don't bleed into the visible area.
+const INACTIVE_LAYER_STYLE = StyleSheet.create({
+    wrapper: {
+        height: 0,
+        left: 0,
+        overflow: "hidden",
+        position: "absolute",
+        right: 0,
+        top: 0,
+    },
+}).wrapper;
+
+export const LegendListDatasets = typedMemo(
+    typedForwardRef(function LegendListDatasets<T>(
+        props: LegendListDatasetsProps<T>,
+        _forwardedRef: ForwardedRef<LegendListRef>,
+    ) {
+        const {
+            datasets,
+            renderItem,
+            drawDistance,
+            enableAverages,
+            estimatedItemSize,
+            estimatedListSize,
+            extraData,
+            getEstimatedItemSize,
+            getFixedItemSize,
+            getItemType,
+            horizontal,
+            initialContainerPoolRatio,
+            initialHeaderSize,
+            itemsAreEqual,
+            keyExtractor,
+            ListEmptyComponent,
+            ListHeaderComponent,
+            ListHeaderComponentStyle,
+            ListFooterComponent,
+            ListFooterComponentStyle,
+            maintainScrollAtEnd,
+            maintainScrollAtEndThreshold,
+            maintainVisibleContentPosition,
+            numColumns,
+            onEndReached,
+            onEndReachedThreshold,
+            onItemSizeChanged,
+            onLayout: onLayoutProp,
+            onLoad,
+            onMomentumScrollEnd,
+            onRefresh,
+            onScroll: onScrollProp,
+            onStartReached,
+            onStartReachedThreshold,
+            onStickyHeaderChange,
+            onViewableItemsChanged,
+            progressViewOffset,
+            recycleItems,
+            refreshControl,
+            refreshing,
+            refScrollView,
+            scrollEventThrottle,
+            snapToIndices,
+            stickyIndices,
+            style: styleProp,
+            suggestEstimatedItemSize,
+            viewabilityConfig,
+            viewabilityConfigCallbackPairs,
+            waitForInitialLayout,
+            stickyHeaderConfig,
+            ItemSeparatorComponent,
+            columnWrapperStyle,
+            contentContainerStyle,
+            dataVersion,
+            alignItemsAtEnd,
+            ...rest
+        } = props;
+
+        const refScroller = useRef<ScrollView>(null);
+        const combinedRef = useCombinedRef(refScroller, refScrollView);
+
+        // Track current scroll offset so we can pass it to a newly-activated dataset
+        const currentScrollRef = useRef(0);
+
+        // One ref slot per dataset, indexed by position
+        const layerRefs = useRef<Array<DatasetLayerHandle | null>>([]);
+
+        const activeIndex = datasets.findIndex((d) => d.active);
+        const prevActiveIndexRef = useRef(activeIndex);
+
+        // When active dataset changes, tell the newly active layer to catch up
+        useLayoutEffect(() => {
+            const prev = prevActiveIndexRef.current;
+            prevActiveIndexRef.current = activeIndex;
+            if (prev !== activeIndex && activeIndex >= 0) {
+                layerRefs.current[activeIndex]?.activate(currentScrollRef.current);
+            }
+        }, [activeIndex]);
+
+        const onScrollHandler = useCallback(
+            (event: NativeSyntheticEvent<NativeScrollEvent>) => {
+                const offset = event.nativeEvent.contentOffset[horizontal ? "x" : "y"];
+                currentScrollRef.current = offset;
+                if (activeIndex >= 0) {
+                    layerRefs.current[activeIndex]?.onScrollOffset(offset);
+                }
+                onScrollProp?.(event);
+            },
+            [activeIndex, horizontal, onScrollProp],
+        );
+
+        const onLayoutChange = useCallback((layout: LayoutRectangle) => {
+            // Propagate viewport size to ALL layers so each can allocate containers
+            for (const ref of layerRefs.current) {
+                ref?.setViewportLayout({
+                    height: layout.height,
+                    width: layout.width,
+                    x: 0,
+                    y: 0,
+                });
+            }
+        }, []);
+
+        const { onLayout } = useOnLayoutSync({
+            onLayoutChange,
+            onLayoutProp,
+            ref: refScroller as unknown as React.RefObject<View>,
+        });
+
+        const onLayoutHeader = useCallback(
+            (rect: LayoutRectangle) => {
+                const size = rect[horizontal ? "width" : "height"];
+                // All layers need the same header size for correct scroll calculations
+                for (const ref of layerRefs.current) {
+                    ref?.setHeaderSize(size);
+                }
+            },
+            [horizontal],
+        );
+
+        // Shared props forwarded to every DatasetLayer
+        const sharedLayerProps = useMemo(
+            () => ({
+                alignItemsAtEnd,
+                columnWrapperStyle,
+                contentContainerStyle,
+                dataVersion,
+                drawDistance,
+                enableAverages,
+                estimatedItemSize,
+                estimatedListSize,
+                extraData,
+                getEstimatedItemSize,
+                getFixedItemSize,
+                getItemType,
+                horizontal,
+                ItemSeparatorComponent,
+                initialContainerPoolRatio,
+                initialHeaderSize,
+                itemsAreEqual,
+                keyExtractor,
+                maintainScrollAtEnd,
+                maintainScrollAtEndThreshold,
+                maintainVisibleContentPosition,
+                numColumns,
+                onEndReached,
+                onEndReachedThreshold,
+                onItemSizeChanged,
+                onLoad,
+                onStartReached,
+                onStartReachedThreshold,
+                onStickyHeaderChange,
+                onViewableItemsChanged,
+                recycleItems,
+                renderItem,
+                snapToIndices,
+                stickyHeaderConfig,
+                stickyIndices,
+                suggestEstimatedItemSize,
+                viewabilityConfig,
+                viewabilityConfigCallbackPairs,
+                waitForInitialLayout,
+            }),
+            [
+                alignItemsAtEnd,
+                columnWrapperStyle,
+                contentContainerStyle,
+                dataVersion,
+                drawDistance,
+                enableAverages,
+                estimatedItemSize,
+                estimatedListSize,
+                extraData,
+                getEstimatedItemSize,
+                getFixedItemSize,
+                getItemType,
+                horizontal,
+                initialContainerPoolRatio,
+                initialHeaderSize,
+                ItemSeparatorComponent,
+                itemsAreEqual,
+                keyExtractor,
+                maintainScrollAtEnd,
+                maintainScrollAtEndThreshold,
+                maintainVisibleContentPosition,
+                numColumns,
+                onEndReached,
+                onEndReachedThreshold,
+                onItemSizeChanged,
+                onLoad,
+                onStartReached,
+                onStartReachedThreshold,
+                onStickyHeaderChange,
+                onViewableItemsChanged,
+                recycleItems,
+                renderItem,
+                snapToIndices,
+                stickyHeaderConfig,
+                stickyIndices,
+                suggestEstimatedItemSize,
+                viewabilityConfig,
+                viewabilityConfigCallbackPairs,
+                waitForInitialLayout,
+            ],
+        );
+
+        const style = styleProp ? StyleSheet.flatten(styleProp) : undefined;
+
+        const activeDataset = activeIndex >= 0 ? datasets[activeIndex] : undefined;
+        const showEmpty = ListEmptyComponent && activeDataset && activeDataset.data.length === 0;
+
+        return (
+            <Animated.ScrollView
+                {...rest}
+                contentContainerStyle={contentContainerStyle}
+                horizontal={horizontal}
+                maintainVisibleContentPosition={maintainVisibleContentPosition ? { minIndexForVisible: 0 } : undefined}
+                onLayout={onLayout}
+                onMomentumScrollEnd={onMomentumScrollEnd}
+                onScroll={onScrollHandler}
+                ref={combinedRef}
+                refreshControl={
+                    refreshControl
+                        ? refreshControl
+                        : onRefresh && (
+                              <RefreshControl
+                                  onRefresh={onRefresh}
+                                  progressViewOffset={progressViewOffset}
+                                  refreshing={!!refreshing}
+                              />
+                          )
+                }
+                scrollEventThrottle={Platform.OS === "web" ? 16 : scrollEventThrottle}
+                style={style}
+            >
+                {ListHeaderComponent && (
+                    <LayoutView onLayoutChange={onLayoutHeader} style={ListHeaderComponentStyle}>
+                        {getComponent(ListHeaderComponent)}
+                    </LayoutView>
+                )}
+                {showEmpty && getComponent(ListEmptyComponent)}
+                {!showEmpty &&
+                    datasets.map((dataset, index) => (
+                        <View key={dataset.key} style={dataset.active ? undefined : INACTIVE_LAYER_STYLE}>
+                            <DatasetLayer
+                                {...sharedLayerProps}
+                                active={dataset.active}
+                                data={dataset.data}
+                                ref={(handle: DatasetLayerHandle | null) => {
+                                    layerRefs.current[index] = handle;
+                                }}
+                                refScroller={refScroller}
+                            />
+                        </View>
+                    ))}
+                {ListFooterComponent && (
+                    <View style={ListFooterComponentStyle}>{getComponent(ListFooterComponent)}</View>
+                )}
+            </Animated.ScrollView>
+        );
+    }),
+);

--- a/src/components/LegendListDatasets.tsx
+++ b/src/components/LegendListDatasets.tsx
@@ -1,7 +1,7 @@
 // biome-ignore lint/style/useImportType: Leaving this out makes it crash in some environments
 import * as React from "react";
 import type { ForwardedRef } from "react";
-import { useCallback, useLayoutEffect, useMemo, useRef } from "react";
+import { useCallback, useEffect, useImperativeHandle, useLayoutEffect, useMemo, useRef, useState } from "react";
 import {
     Animated,
     type LayoutRectangle,
@@ -16,11 +16,15 @@ import {
 
 import { DatasetLayer, type DatasetLayerHandle } from "@/components/DatasetLayer";
 import { LayoutView } from "@/components/LayoutView";
+import { scrollTo } from "@/core/scrollTo";
+import { scrollToIndex } from "@/core/scrollToIndex";
 import { useCombinedRef } from "@/hooks/useCombinedRef";
 import { useOnLayoutSync } from "@/hooks/useOnLayoutSync";
-import type { LegendListDatasetsProps, LegendListRef } from "@/types";
+import { listen$, peek$, set$ } from "@/state/state";
+import type { LegendListDatasetsProps, LegendListRef, ScrollState } from "@/types";
 import { typedForwardRef, typedMemo } from "@/types";
 import { getComponent } from "@/utils/getComponent";
+import { getId } from "@/utils/getId";
 
 // Style applied to wrapper of each inactive dataset layer so it takes no layout space
 // and its contents (items at translateY: -9999) don't bleed into the visible area.
@@ -38,11 +42,15 @@ const INACTIVE_LAYER_STYLE = StyleSheet.create({
 export const LegendListDatasets = typedMemo(
     typedForwardRef(function LegendListDatasets<T>(
         props: LegendListDatasetsProps<T>,
-        _forwardedRef: ForwardedRef<LegendListRef>,
+        forwardedRef: ForwardedRef<LegendListRef>,
     ) {
         const {
             datasets,
             renderItem,
+            alignItemsAtEnd,
+            columnWrapperStyle,
+            contentContainerStyle,
+            dataVersion,
             drawDistance,
             enableAverages,
             estimatedItemSize,
@@ -54,7 +62,10 @@ export const LegendListDatasets = typedMemo(
             horizontal,
             initialContainerPoolRatio,
             initialHeaderSize,
+            initialScrollIndex,
+            initialScrollOffset,
             itemsAreEqual,
+            ItemSeparatorComponent,
             keyExtractor,
             ListEmptyComponent,
             ListHeaderComponent,
@@ -84,18 +95,13 @@ export const LegendListDatasets = typedMemo(
             refScrollView,
             scrollEventThrottle,
             snapToIndices,
+            stickyHeaderConfig,
             stickyIndices,
             style: styleProp,
             suggestEstimatedItemSize,
             viewabilityConfig,
             viewabilityConfigCallbackPairs,
             waitForInitialLayout,
-            stickyHeaderConfig,
-            ItemSeparatorComponent,
-            columnWrapperStyle,
-            contentContainerStyle,
-            dataVersion,
-            alignItemsAtEnd,
             ...rest
         } = props;
 
@@ -109,6 +115,10 @@ export const LegendListDatasets = typedMemo(
         const layerRefs = useRef<Array<DatasetLayerHandle | null>>([]);
 
         const activeIndex = datasets.findIndex((d) => d.active);
+        // Stable ref so imperative handle methods always see the current active index
+        const activeIndexRef = useRef(activeIndex);
+        activeIndexRef.current = activeIndex;
+
         const prevActiveIndexRef = useRef(activeIndex);
 
         // When active dataset changes, tell the newly active layer to catch up
@@ -124,23 +134,19 @@ export const LegendListDatasets = typedMemo(
             (event: NativeSyntheticEvent<NativeScrollEvent>) => {
                 const offset = event.nativeEvent.contentOffset[horizontal ? "x" : "y"];
                 currentScrollRef.current = offset;
-                if (activeIndex >= 0) {
-                    layerRefs.current[activeIndex]?.onScrollOffset(offset);
+                const idx = activeIndexRef.current;
+                if (idx >= 0) {
+                    layerRefs.current[idx]?.onScrollOffset(offset);
                 }
                 onScrollProp?.(event);
             },
-            [activeIndex, horizontal, onScrollProp],
+            [horizontal, onScrollProp],
         );
 
         const onLayoutChange = useCallback((layout: LayoutRectangle) => {
             // Propagate viewport size to ALL layers so each can allocate containers
             for (const ref of layerRefs.current) {
-                ref?.setViewportLayout({
-                    height: layout.height,
-                    width: layout.width,
-                    x: 0,
-                    y: 0,
-                });
+                ref?.setViewportLayout({ height: layout.height, width: layout.width, x: 0, y: 0 });
             }
         }, []);
 
@@ -153,13 +159,126 @@ export const LegendListDatasets = typedMemo(
         const onLayoutHeader = useCallback(
             (rect: LayoutRectangle) => {
                 const size = rect[horizontal ? "width" : "height"];
-                // All layers need the same header size for correct scroll calculations
                 for (const ref of layerRefs.current) {
                     ref?.setHeaderSize(size);
                 }
             },
             [horizontal],
         );
+
+        // Subscribe to the active dataset's snapToOffsets so the ScrollView stays in sync
+        const [snapOffsets, setSnapOffsets] = useState<number[] | undefined>(undefined);
+        useEffect(() => {
+            if (!snapToIndices) {
+                setSnapOffsets(undefined);
+                return;
+            }
+            const activeLayer = layerRefs.current[activeIndex];
+            if (!activeLayer) return;
+            const ctx = activeLayer.getCtx();
+            setSnapOffsets(peek$(ctx, "snapToOffsets"));
+            return listen$(ctx, "snapToOffsets", setSnapOffsets);
+        }, [activeIndex, snapToIndices]);
+
+        // Wire up the imperative ref — delegates to the active dataset's ctx/state
+        useImperativeHandle(forwardedRef, () => {
+            const getActiveCtx = () => {
+                const layer = layerRefs.current[activeIndexRef.current];
+                return layer?.getCtx();
+            };
+            const getActiveState = () => {
+                const layer = layerRefs.current[activeIndexRef.current];
+                return layer?.getState();
+            };
+
+            const scrollIndexIntoView = (options: Parameters<LegendListRef["scrollIndexIntoView"]>[0]) => {
+                const ctx = getActiveCtx();
+                const state = getActiveState();
+                if (!ctx || !state) return;
+                const { index, ...rest } = options;
+                const { startNoBuffer, endNoBuffer } = state;
+                if (index < startNoBuffer || index > endNoBuffer) {
+                    const viewPosition = index < startNoBuffer ? 0 : 1;
+                    scrollToIndex(ctx, state, { ...rest, index, viewPosition });
+                }
+            };
+
+            return {
+                flashScrollIndicators: () => refScroller.current!.flashScrollIndicators(),
+                getNativeScrollRef: () => refScroller.current!,
+                getScrollableNode: () => refScroller.current!.getScrollableNode(),
+                getScrollResponder: () => refScroller.current!.getScrollResponder(),
+                getState: (): ScrollState => {
+                    const state = getActiveState();
+                    if (!state) return {} as ScrollState;
+                    return {
+                        activeStickyIndex: state.activeStickyIndex,
+                        contentLength: state.totalSize,
+                        data: state.props.data,
+                        end: state.endNoBuffer,
+                        endBuffered: state.endBuffered,
+                        isAtEnd: state.isAtEnd,
+                        isAtStart: state.isAtStart,
+                        positionAtIndex: (index: number) => state.positions.get(getId(state, index))!,
+                        positions: state.positions,
+                        scroll: state.scroll,
+                        scrollLength: state.scrollLength,
+                        sizeAtIndex: (index: number) => state.sizesKnown.get(getId(state, index))!,
+                        sizes: state.sizesKnown,
+                        start: state.startNoBuffer,
+                        startBuffered: state.startBuffered,
+                    };
+                },
+                scrollIndexIntoView,
+                scrollItemIntoView: ({ item, ...options }) => {
+                    const state = getActiveState();
+                    if (!state) return;
+                    const index = state.props.data.indexOf(item);
+                    if (index !== -1) scrollIndexIntoView({ index, ...options });
+                },
+                scrollToEnd: (options) => {
+                    const ctx = getActiveCtx();
+                    const state = getActiveState();
+                    if (!ctx || !state) return;
+                    const index = state.props.data.length - 1;
+                    if (index !== -1) {
+                        const footerSize = peek$(ctx, "footerSize") || 0;
+                        scrollToIndex(ctx, state, {
+                            index,
+                            viewOffset: -footerSize + (options?.viewOffset || 0),
+                            viewPosition: 1,
+                            ...options,
+                        });
+                    }
+                },
+                scrollToIndex: (params) => {
+                    const ctx = getActiveCtx();
+                    const state = getActiveState();
+                    if (ctx && state) scrollToIndex(ctx, state, params);
+                },
+                scrollToItem: ({ item, ...options }) => {
+                    const ctx = getActiveCtx();
+                    const state = getActiveState();
+                    if (!ctx || !state) return;
+                    const index = state.props.data.indexOf(item);
+                    if (index !== -1) scrollToIndex(ctx, state, { index, ...options });
+                },
+                scrollToOffset: (params) => {
+                    const state = getActiveState();
+                    if (state) scrollTo(state, params);
+                },
+                setScrollProcessingEnabled: (enabled: boolean) => {
+                    const state = getActiveState();
+                    if (state) state.scrollProcessingEnabled = enabled;
+                },
+                setVisibleContentAnchorOffset: (value: number | ((value: number) => number)) => {
+                    const ctx = getActiveCtx();
+                    if (!ctx) return;
+                    const val = typeof value === "function" ? value(peek$(ctx, "scrollAdjustUserOffset") || 0) : value;
+                    set$(ctx, "scrollAdjustUserOffset", val);
+                },
+            };
+        }, []);
 
         // Shared props forwarded to every DatasetLayer
         const sharedLayerProps = useMemo(
@@ -180,6 +299,8 @@ export const LegendListDatasets = typedMemo(
                 ItemSeparatorComponent,
                 initialContainerPoolRatio,
                 initialHeaderSize,
+                initialScrollIndex,
+                initialScrollOffset,
                 itemsAreEqual,
                 keyExtractor,
                 maintainScrollAtEnd,
@@ -220,6 +341,8 @@ export const LegendListDatasets = typedMemo(
                 horizontal,
                 initialContainerPoolRatio,
                 initialHeaderSize,
+                initialScrollIndex,
+                initialScrollOffset,
                 ItemSeparatorComponent,
                 itemsAreEqual,
                 keyExtractor,
@@ -274,6 +397,7 @@ export const LegendListDatasets = typedMemo(
                           )
                 }
                 scrollEventThrottle={Platform.OS === "web" ? 16 : scrollEventThrottle}
+                snapToOffsets={snapOffsets}
                 style={style}
             >
                 {ListHeaderComponent && (

--- a/src/components/LegendListDatasets.tsx
+++ b/src/components/LegendListDatasets.tsx
@@ -50,7 +50,7 @@ export const LegendListDatasets = typedMemo(
             alignItemsAtEnd,
             columnWrapperStyle,
             contentContainerStyle,
-            dataVersion,
+            dataVersion: _dataVersion, // per-dataset via DatasetEntry.dataVersion; destructured to exclude from ...rest
             drawDistance,
             enableAverages,
             estimatedItemSize,
@@ -280,13 +280,44 @@ export const LegendListDatasets = typedMemo(
             };
         }, []);
 
-        // Shared props forwarded to every DatasetLayer
+        // Stabilize callbacks via refs so that un-memoized inline functions in the
+        // parent don't invalidate sharedLayerProps and re-render all dataset layers.
+        const renderItemRef = useRef(renderItem);
+        renderItemRef.current = renderItem;
+        const stableRenderItem = useCallback((p: any) => (renderItemRef.current as any)(p), []);
+
+        const keyExtractorRef = useRef(keyExtractor);
+        keyExtractorRef.current = keyExtractor;
+        const stableKeyExtractor = keyExtractor
+            ? useCallback((item: any, index: number) => keyExtractorRef.current!(item, index), [])
+            : undefined;
+
+        const onEndReachedRef = useRef(onEndReached);
+        onEndReachedRef.current = onEndReached;
+        const stableOnEndReached = onEndReached
+            ? useCallback((info: any) => onEndReachedRef.current?.(info), [])
+            : undefined;
+
+        const onStartReachedRef = useRef(onStartReached);
+        onStartReachedRef.current = onStartReached;
+        const stableOnStartReached = onStartReached
+            ? useCallback((info: any) => onStartReachedRef.current?.(info), [])
+            : undefined;
+
+        const onViewableItemsChangedRef = useRef(onViewableItemsChanged);
+        onViewableItemsChangedRef.current = onViewableItemsChanged;
+        const stableOnViewableItemsChanged = onViewableItemsChanged
+            ? useCallback((info: any) => onViewableItemsChangedRef.current?.(info), [])
+            : undefined;
+
+        // Structural/layout props that legitimately need to re-propagate when changed.
+        // Callbacks are excluded — they're stabilized via refs above.
+        // dataVersion is excluded — it's per-dataset via DatasetEntry.dataVersion.
         const sharedLayerProps = useMemo(
             () => ({
                 alignItemsAtEnd,
                 columnWrapperStyle,
                 contentContainerStyle,
-                dataVersion,
                 drawDistance,
                 enableAverages,
                 estimatedItemSize,
@@ -302,21 +333,21 @@ export const LegendListDatasets = typedMemo(
                 initialScrollIndex,
                 initialScrollOffset,
                 itemsAreEqual,
-                keyExtractor,
+                keyExtractor: stableKeyExtractor,
                 maintainScrollAtEnd,
                 maintainScrollAtEndThreshold,
                 maintainVisibleContentPosition,
                 numColumns,
-                onEndReached,
+                onEndReached: stableOnEndReached,
                 onEndReachedThreshold,
                 onItemSizeChanged,
                 onLoad,
-                onStartReached,
+                onStartReached: stableOnStartReached,
                 onStartReachedThreshold,
                 onStickyHeaderChange,
-                onViewableItemsChanged,
+                onViewableItemsChanged: stableOnViewableItemsChanged,
                 recycleItems,
-                renderItem,
+                renderItem: stableRenderItem,
                 snapToIndices,
                 stickyHeaderConfig,
                 stickyIndices,
@@ -329,7 +360,6 @@ export const LegendListDatasets = typedMemo(
                 alignItemsAtEnd,
                 columnWrapperStyle,
                 contentContainerStyle,
-                dataVersion,
                 drawDistance,
                 enableAverages,
                 estimatedItemSize,
@@ -339,27 +369,22 @@ export const LegendListDatasets = typedMemo(
                 getFixedItemSize,
                 getItemType,
                 horizontal,
+                ItemSeparatorComponent,
                 initialContainerPoolRatio,
                 initialHeaderSize,
                 initialScrollIndex,
                 initialScrollOffset,
-                ItemSeparatorComponent,
                 itemsAreEqual,
-                keyExtractor,
                 maintainScrollAtEnd,
                 maintainScrollAtEndThreshold,
                 maintainVisibleContentPosition,
                 numColumns,
-                onEndReached,
                 onEndReachedThreshold,
                 onItemSizeChanged,
                 onLoad,
-                onStartReached,
                 onStartReachedThreshold,
                 onStickyHeaderChange,
-                onViewableItemsChanged,
                 recycleItems,
-                renderItem,
                 snapToIndices,
                 stickyHeaderConfig,
                 stickyIndices,
@@ -413,6 +438,7 @@ export const LegendListDatasets = typedMemo(
                                 {...sharedLayerProps}
                                 active={dataset.active}
                                 data={dataset.data}
+                                dataVersion={dataset.dataVersion}
                                 ref={(handle: DatasetLayerHandle | null) => {
                                     layerRefs.current[index] = handle;
                                 }}

--- a/src/core/calculateItemsInView.ts
+++ b/src/core/calculateItemsInView.ts
@@ -209,7 +209,7 @@ export function calculateItemsInView(
         }
 
         const scrollTopBuffered = scroll - scrollBufferTop;
-        const scrollBottom = scroll + scrollLength + (scroll < 0 ? -scroll : 0);
+        const scrollBottom = Math.max(0, scroll + scrollLength);
         const scrollBottomBuffered = scrollBottom + scrollBufferBottom;
 
         // Check precomputed scroll range to see if we can skip this check

--- a/src/core/doInitialAllocateContainers.ts
+++ b/src/core/doInitialAllocateContainers.ts
@@ -39,7 +39,8 @@ export function doInitialAllocateContainers(ctx: StateContext, state: InternalSt
         } else {
             averageItemSize = estimatedItemSize!;
         }
-        const numContainers = Math.ceil(((scrollLength + scrollBuffer * 2) / averageItemSize!) * numColumns);
+        const headerSize = peek$(ctx, "headerSize") || 0;
+        const numContainers = Math.ceil((((scrollLength - headerSize) + scrollBuffer * 2) / averageItemSize!) * numColumns);
 
         for (let i = 0; i < numContainers; i++) {
             set$(ctx, `containerPosition${i}`, POSITION_OUT_OF_VIEW);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 export { LegendList } from "@/components/LegendList";
+export { LegendListDatasets } from "@/components/LegendListDatasets";
 export {
     useIsLastItem,
     useListScrollSize,
@@ -8,4 +9,5 @@ export {
     useViewability,
     useViewabilityAmount,
 } from "@/state/ContextContainer";
+export type { DatasetEntry, LegendListDatasetsProps } from "@/types";
 export type * from "./types";

--- a/src/types.ts
+++ b/src/types.ts
@@ -176,6 +176,12 @@ interface LegendListSpecificProps<ItemT, TItemType extends string | undefined> {
     ListHeaderComponentStyle?: StyleProp<ViewStyle> | undefined;
 
     /**
+     * Known height of the ListHeaderComponent. Provide this when the header height is known
+     * ahead of time to avoid overcalculating containers on the first render.
+     */
+    initialHeaderSize?: number;
+
+    /**
      * If true, auto-scrolls to end when new items are added.
      * @default false
      */

--- a/src/types.ts
+++ b/src/types.ts
@@ -381,6 +381,12 @@ export interface DatasetEntry<ItemT> {
     data: ReadonlyArray<ItemT>;
     /** Whether this dataset is the currently visible one */
     active: boolean;
+    /**
+     * Per-dataset version token. Increment this when mutating the data array
+     * in place for this specific dataset. Using the shared `dataVersion` prop
+     * would trigger a full rebuild on ALL datasets simultaneously.
+     */
+    dataVersion?: Key;
 }
 
 export type LegendListDatasetsProps<ItemT = any> = Omit<LegendListProps<ItemT>, "data" | "children" | "renderItem"> & {

--- a/src/types.ts
+++ b/src/types.ts
@@ -374,6 +374,22 @@ export interface ColumnWrapperStyle {
 
 export type LegendListProps<ItemT = any> = LegendListPropsBase<ItemT, ComponentProps<typeof ScrollView>>;
 
+export interface DatasetEntry<ItemT> {
+    /** Unique key for this dataset — used as a React key and for identity */
+    key: string;
+    /** Data array for this dataset */
+    data: ReadonlyArray<ItemT>;
+    /** Whether this dataset is the currently visible one */
+    active: boolean;
+}
+
+export type LegendListDatasetsProps<ItemT = any> = Omit<LegendListProps<ItemT>, "data" | "children" | "renderItem"> & {
+    datasets: DatasetEntry<ItemT>[];
+    renderItem:
+        | ((props: LegendListRenderItemProps<ItemT, string | undefined>) => ReactNode)
+        | React.ComponentType<LegendListRenderItemProps<ItemT, string | undefined>>;
+};
+
 export interface InternalState {
     positions: Map<string, number>;
     columns: Map<string, number>;


### PR DESCRIPTION
We had a problem where our ListHeaderComponent was like 90% of the screen. It seemed like the container pool is over calculated on the initial render because `headerSize` state initializes to 0. This caused for a bunch of additional containers to be allocated and a bunch of items rendering on the first frame

Two fixes:
- Add `initialHeaderSize` prop that seeds the headerSize state before the first render, so doInitialAllocateContainers uses the correct available scroll area from frame 0
- Fix scrollBottom formula in calculateItemsInView: the previous `scroll < 0 ? -scroll : 0` term cancelled out topPad when scroll=0, causing scrollBottom to equal scrollLength regardless of header size