### PR TITLE
Add +html.tsx to Expo example for better universal support

### DIFF
--- a/example/app/+html.tsx
+++ b/example/app/+html.tsx
@@ -1,0 +1,31 @@
+// Learn more https://docs.expo.dev/router/reference/static-rendering/#root-html
+
+import { ScrollViewStyleReset } from "expo-router/html";
+
+// This file is web-only and used to configure the root HTML for every
+// web page during static rendering.
+// The contents of this function only run in Node.js environments and
+// do not have access to the DOM or browser APIs.
+export default function Root({ children }: { children: React.ReactNode }) {
+    return (
+        <html lang="en">
+            <head>
+                <meta charSet="utf-8" />
+                <meta content="IE=edge" httpEquiv="X-UA-Compatible" />
+                {/* maximum-scale=1 prevents iOS from zooming in when an input is focused.
+                    user-scalable=no disables pinch-to-zoom on supporting browsers. */}
+                <meta
+                    content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no, shrink-to-fit=no"
+                    name="viewport"
+                />
+
+                {/*
+                  Disable body scrolling on web. This makes ScrollView components work closer to how they do on native.
+                  However, body scrolling is often nice to have for mobile web. If you want to enable it, remove this line.
+                */}
+                <ScrollViewStyleReset />
+            </head>
+            <body>{children}</body>
+        </html>
+    );
+}

--- a/example/app/+html.tsx
+++ b/example/app/+html.tsx
@@ -12,12 +12,7 @@ export default function Root({ children }: { children: React.ReactNode }) {
             <head>
                 <meta charSet="utf-8" />
                 <meta content="IE=edge" httpEquiv="X-UA-Compatible" />
-                {/* maximum-scale=1 prevents iOS from zooming in when an input is focused.
-                    user-scalable=no disables pinch-to-zoom on supporting browsers. */}
-                <meta
-                    content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no, shrink-to-fit=no"
-                    name="viewport"
-                />
+                <meta content="width=device-width, initial-scale=1, shrink-to-fit=no" name="viewport" />
 
                 {/*
                   Disable body scrolling on web. This makes ScrollView components work closer to how they do on native.


### PR DESCRIPTION
Many people using this library use expo-web so it's good to make sure the example app works well with expo-web.