### PR TITLE
feat: add estimatedHeaderSize prop to limit initial rendered items below large headers

### DIFF
--- a/__tests__/core/calculateItemsInView.test.ts
+++ b/__tests__/core/calculateItemsInView.test.ts
@@ -17,6 +17,40 @@ describe("calculateItemsInView", () => {
     let mockCtx: StateContext;
     let mockState: InternalState;
 
+    function setupFixedSizeItems(count: number, itemSize: number) {
+        mockState.props.data = Array.from({ length: count }, (_, i) => ({ id: i }));
+        mockState.props.getFixedItemSize = () => itemSize;
+        mockState.props.drawDistance = 0;
+        mockState.props.scrollBuffer = 0;
+        mockState.scroll = 0;
+        mockState.scrollLength = 1000;
+        mockCtx.values.set("numContainers", count);
+        mockCtx.values.set("totalSize", count * itemSize);
+
+        for (let i = 0; i < count; i++) {
+            const id = `item_${i}`;
+            mockState.idCache[i] = id;
+            mockState.indexByKey.set(id, i);
+            setLayoutValue(mockState, "positions", id, i * itemSize);
+            mockState.sizes.set(id, itemSize);
+            mockState.sizesKnown.set(id, itemSize);
+        }
+    }
+
+    function getRenderedContainerKeys() {
+        const keys: string[] = [];
+        const numContainers = mockCtx.values.get("numContainers") || 0;
+
+        for (let i = 0; i < numContainers; i++) {
+            const key = mockCtx.values.get(`containerItemKey${i}`);
+            if (key !== undefined) {
+                keys.push(key);
+            }
+        }
+
+        return keys;
+    }
+
     beforeEach(() => {
         mockCtx = createMockContext(
             {
@@ -301,6 +335,56 @@ describe("calculateItemsInView", () => {
 
             expect(mockState.startNoBuffer).toBe(2);
             expect(mockState.endNoBuffer).toBe(6);
+        });
+
+        it("should render a full viewport of items when there is no header size", () => {
+            setupFixedSizeItems(20, 100);
+
+            calculateItemsInView(mockCtx);
+
+            expect(getRenderedContainerKeys()).toEqual([
+                "item_0",
+                "item_1",
+                "item_2",
+                "item_3",
+                "item_4",
+                "item_5",
+                "item_6",
+                "item_7",
+                "item_8",
+                "item_9",
+                "item_10",
+            ]);
+        });
+
+        it("should limit initial rendered items to the space below a known header size", () => {
+            setupFixedSizeItems(20, 100);
+            mockCtx.values.set("headerSize", 800);
+
+            calculateItemsInView(mockCtx);
+
+            expect(getRenderedContainerKeys()).toEqual(["item_0", "item_1", "item_2"]);
+        });
+
+        it("should preserve a full viewport of items during native overscroll", () => {
+            setupFixedSizeItems(20, 100);
+            mockState.scroll = -80;
+
+            calculateItemsInView(mockCtx);
+
+            expect(getRenderedContainerKeys()).toEqual([
+                "item_0",
+                "item_1",
+                "item_2",
+                "item_3",
+                "item_4",
+                "item_5",
+                "item_6",
+                "item_7",
+                "item_8",
+                "item_9",
+                "item_10",
+            ]);
         });
     });
 

--- a/src/components/LegendList.tsx
+++ b/src/components/LegendList.tsx
@@ -135,7 +135,7 @@ const LegendListInner = typedForwardRef(function LegendListInner<T>(
         getItemType,
         horizontal,
         initialContainerPoolRatio = 3,
-        initialHeaderSize,
+        initialHeaderHeight,
         initialScrollAtEnd = false,
         initialScrollIndex: initialScrollIndexProp,
         initialScrollOffset: initialScrollOffsetProp,
@@ -254,8 +254,8 @@ const LegendListInner = typedForwardRef(function LegendListInner<T>(
     const [canRender, setCanRender] = React.useState(!IsNewArchitecture);
 
     const ctx = useStateContext();
-    if (initialHeaderSize !== undefined && !ctx.internalState) {
-        ctx.values.set("headerSize", initialHeaderSize);
+    if (initialHeaderHeight !== undefined && !ctx.internalState) {
+        ctx.values.set("headerSize", initialHeaderHeight);
     }
     ctx.columnWrapperStyle =
         columnWrapperStyle || (contentContainerStyle ? createColumnWrapperStyle(contentContainerStyle) : undefined);

--- a/src/components/LegendList.tsx
+++ b/src/components/LegendList.tsx
@@ -135,6 +135,7 @@ const LegendListInner = typedForwardRef(function LegendListInner<T>(
         getItemType,
         horizontal,
         initialContainerPoolRatio = 3,
+        initialHeaderSize,
         initialScrollAtEnd = false,
         initialScrollIndex: initialScrollIndexProp,
         initialScrollOffset: initialScrollOffsetProp,
@@ -253,6 +254,9 @@ const LegendListInner = typedForwardRef(function LegendListInner<T>(
     const [canRender, setCanRender] = React.useState(!IsNewArchitecture);
 
     const ctx = useStateContext();
+    if (initialHeaderSize !== undefined && !ctx.internalState) {
+        ctx.values.set("headerSize", initialHeaderSize);
+    }
     ctx.columnWrapperStyle =
         columnWrapperStyle || (contentContainerStyle ? createColumnWrapperStyle(contentContainerStyle) : undefined);
 

--- a/src/components/LegendList.tsx
+++ b/src/components/LegendList.tsx
@@ -135,7 +135,7 @@ const LegendListInner = typedForwardRef(function LegendListInner<T>(
         getItemType,
         horizontal,
         initialContainerPoolRatio = 3,
-        initialHeaderHeight,
+        initialHeaderSize,
         initialScrollAtEnd = false,
         initialScrollIndex: initialScrollIndexProp,
         initialScrollOffset: initialScrollOffsetProp,
@@ -254,8 +254,8 @@ const LegendListInner = typedForwardRef(function LegendListInner<T>(
     const [canRender, setCanRender] = React.useState(!IsNewArchitecture);
 
     const ctx = useStateContext();
-    if (initialHeaderHeight !== undefined && !ctx.internalState) {
-        ctx.values.set("headerSize", initialHeaderHeight);
+    if (initialHeaderSize !== undefined && !ctx.internalState) {
+        ctx.values.set("headerSize", initialHeaderSize);
     }
     ctx.columnWrapperStyle =
         columnWrapperStyle || (contentContainerStyle ? createColumnWrapperStyle(contentContainerStyle) : undefined);

--- a/src/components/LegendList.tsx
+++ b/src/components/LegendList.tsx
@@ -135,7 +135,7 @@ const LegendListInner = typedForwardRef(function LegendListInner<T>(
         getItemType,
         horizontal,
         initialContainerPoolRatio = 3,
-        initialHeaderSize,
+        estimatedHeaderSize,
         initialScrollAtEnd = false,
         initialScrollIndex: initialScrollIndexProp,
         initialScrollOffset: initialScrollOffsetProp,
@@ -361,8 +361,8 @@ const LegendListInner = typedForwardRef(function LegendListInner<T>(
 
             set$(ctx, "maintainVisibleContentPosition", maintainVisibleContentPositionConfig);
             set$(ctx, "extraData", extraData);
-            if (initialHeaderSize !== undefined) {
-                set$(ctx, "headerSize", initialHeaderSize);
+            if (estimatedHeaderSize !== undefined) {
+                set$(ctx, "headerSize", estimatedHeaderSize);
             }
         }
         refState.current = ctx.state;

--- a/src/components/LegendList.tsx
+++ b/src/components/LegendList.tsx
@@ -254,9 +254,6 @@ const LegendListInner = typedForwardRef(function LegendListInner<T>(
     const [canRender, setCanRender] = React.useState(!IsNewArchitecture);
 
     const ctx = useStateContext();
-    if (initialHeaderSize !== undefined && !ctx.internalState) {
-        ctx.values.set("headerSize", initialHeaderSize);
-    }
     ctx.columnWrapperStyle =
         columnWrapperStyle || (contentContainerStyle ? createColumnWrapperStyle(contentContainerStyle) : undefined);
 
@@ -364,6 +361,9 @@ const LegendListInner = typedForwardRef(function LegendListInner<T>(
 
             set$(ctx, "maintainVisibleContentPosition", maintainVisibleContentPositionConfig);
             set$(ctx, "extraData", extraData);
+            if (initialHeaderSize !== undefined) {
+                set$(ctx, "headerSize", initialHeaderSize);
+            }
         }
         refState.current = ctx.state;
     }

--- a/src/core/calculateItemsInView.ts
+++ b/src/core/calculateItemsInView.ts
@@ -199,7 +199,9 @@ export function calculateItemsInView(
         let scrollTopBuffered = 0;
         let scrollBottom = 0;
         let scrollBottomBuffered = 0;
+        let nativeScrollState = scrollState;
         const updateScroll = (nextScrollState: number) => {
+            nativeScrollState = nextScrollState;
             scrollAdjustPending = peek$(ctx, "scrollAdjustPending") ?? 0;
             scrollAdjustPad = scrollAdjustPending - topPad;
             scroll = Math.round(nextScrollState + scrollExtra + scrollAdjustPad);
@@ -248,8 +250,12 @@ export function calculateItemsInView(
         }
 
         const updateScrollRange = () => {
-            scrollTopBuffered = scroll - scrollBufferTop;
-            scrollBottom = scroll + scrollLength + (scroll < 0 ? -scroll : 0);
+            const scrollStart = Math.max(0, scroll);
+            // Preserve a full item-space viewport during native overscroll without
+            // treating header/padding offset as visible item space.
+            const overscrollBeforeContent = Math.max(0, -nativeScrollState);
+            scrollTopBuffered = scrollStart - scrollBufferTop;
+            scrollBottom = Math.max(scrollStart, scroll + scrollLength + overscrollBeforeContent);
             scrollBottomBuffered = scrollBottom + scrollBufferBottom;
         };
         updateScrollRange();

--- a/src/types.base.ts
+++ b/src/types.base.ts
@@ -223,7 +223,7 @@ interface LegendListSpecificProps<ItemT, TItemType extends string | undefined> {
      * the initial frame, rather than a full screen's worth of items that are hidden behind it.
      * The container pool is still sized for the full viewport so no growth occurs when scrolling.
      */
-    initialHeaderHeight?: number;
+    initialHeaderSize?: number;
 
     /**
      * If true, auto-scrolls to end when new items are added.

--- a/src/types.base.ts
+++ b/src/types.base.ts
@@ -223,7 +223,7 @@ interface LegendListSpecificProps<ItemT, TItemType extends string | undefined> {
      * the initial frame, rather than a full screen's worth of items that are hidden behind it.
      * The container pool is still sized for the full viewport so no growth occurs when scrolling.
      */
-    initialHeaderSize?: number;
+    initialHeaderHeight?: number;
 
     /**
      * If true, auto-scrolls to end when new items are added.

--- a/src/types.base.ts
+++ b/src/types.base.ts
@@ -218,12 +218,12 @@ interface LegendListSpecificProps<ItemT, TItemType extends string | undefined> {
     ListHeaderComponentStyle?: StyleProp<ViewStyle> | undefined;
 
     /**
-     * Known height of the ListHeaderComponent. Provide this when the header height is known
-     * ahead of time so that only the items actually visible below the header are rendered on
-     * the initial frame, rather than a full screen's worth of items that are hidden behind it.
-     * The container pool is still sized for the full viewport so no growth occurs when scrolling.
+     * Estimated height of the ListHeaderComponent. Provide this when the expected header height
+     * is known before layout so that only the items actually visible below the header are rendered
+     * on the initial frame, rather than a full screen's worth of items that are hidden behind it.
+     * The measured header size still replaces this value after layout.
      */
-    initialHeaderSize?: number;
+    estimatedHeaderSize?: number;
 
     /**
      * If true, auto-scrolls to end when new items are added.

--- a/src/types.base.ts
+++ b/src/types.base.ts
@@ -218,6 +218,14 @@ interface LegendListSpecificProps<ItemT, TItemType extends string | undefined> {
     ListHeaderComponentStyle?: StyleProp<ViewStyle> | undefined;
 
     /**
+     * Known height of the ListHeaderComponent. Provide this when the header height is known
+     * ahead of time so that only the items actually visible below the header are rendered on
+     * the initial frame, rather than a full screen's worth of items that are hidden behind it.
+     * The container pool is still sized for the full viewport so no growth occurs when scrolling.
+     */
+    initialHeaderSize?: number;
+
+    /**
      * If true, auto-scrolls to end when new items are added.
      * Use an options object to opt into specific triggers and control whether that scroll is animated.
      * @default false


### PR DESCRIPTION
When a ListHeaderComponent occupies most of the initial viewport, LegendList
would render a full screen's worth of list items even though most are hidden
behind the header. Providing estimatedHeaderSize pre-populates the headerSize
state before the first calculateItemsInView call, so only items visible in
(screenSize - headerSize) are rendered on the initial frame.

The container pool is intentionally sized for the full viewport — not reduced
by the header size — so it never needs to grow when the user scrolls past the header. Native overscroll still preserves a full viewport of item coverage.