### PR TITLE
feat: LegendListDatasets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.19
+- Fix: Add safety checks for getItemType, getEstimatedItemSize, getFixedItemSize, and keyExtractor to prevent calling when index is out of range
+- Fix: Error with animatedProps in reanimated integration
+
 ## 2.0.18
 - Improvement: KeyboardAvoidingLegendList now supports KeyboardGestureArea with improved interactive behavior
 

--- a/DATASETS.md
+++ b/DATASETS.md
@@ -1,0 +1,277 @@
+# Datasets
+
+`LegendListDatasets` lets you render multiple independent lists under a single shared header, footer, and scroll container. This is useful when you have tabbed interfaces where each tab shows a different set of list items — switching between tabs is near-instant because each dataset's containers stay mounted and positioned.
+
+---
+
+## 🤔 Why Datasets?
+
+The common approach to tabbed lists is either:
+
+1. **One list, swap the data** — Every tab switch triggers a full recalculation of positions, container allocation, and item rendering. Expensive.
+2. **Multiple lists in a pager** — Each list has its own ScrollView, so you lose the shared header and need complex scroll synchronization.
+3. **Duplicate the whole screen** — Works, but you get N headers, N scroll positions, and N separate scroll containers.
+
+`LegendListDatasets` solves all three:
+
+* **One ScrollView** with one shared header and footer
+* **N independent list engines** — each dataset has its own container pool, position map, and size cache
+* **Near-instant tab switching** — inactive datasets keep their native layout warm and skip recalculation when reactivated at a similar scroll position
+* **React.Activity integration** — inactive datasets use `<Activity mode="hidden">` to freeze effects while preserving component state
+
+---
+
+## 💻 Basic Usage
+
+```tsx
+import { LegendListDatasets } from "@legendapp/list";
+import type { DatasetEntry } from "@legendapp/list";
+
+const [activeTab, setActiveTab] = useState<"recent" | "popular" | "favorites">("recent");
+
+const datasets: DatasetEntry<Item>[] = [
+    { key: "recent", data: recentItems, active: activeTab === "recent" },
+    { key: "popular", data: popularItems, active: activeTab === "popular" },
+    { key: "favorites", data: favoriteItems, active: activeTab === "favorites" },
+];
+
+<LegendListDatasets
+    datasets={datasets}
+    renderItem={({ item }) => <ItemRow item={item} />}
+    keyExtractor={(item) => item.id}
+    estimatedItemSize={60}
+    recycleItems
+    ListHeaderComponent={
+        <View>
+            <ProfileHeader />
+            <TabBar activeTab={activeTab} onTabChange={setActiveTab} />
+        </View>
+    }
+/>
+```
+
+Only **one** dataset should have `active: true` at a time. The active dataset's items participate in scroll layout. Inactive datasets are hidden with `opacity: 0` and `pointerEvents: 'none'` — their containers stay mounted and positioned so switching back is instant.
+
+---
+
+## ✨ DatasetEntry Props
+
+Each entry in the `datasets` array supports these properties:
+
+| Prop | Type | Required | Description |
+|------|------|----------|-------------|
+| `key` | `string` | Yes | Unique key for this dataset. Used as a React key. |
+| `data` | `ReadonlyArray<T>` | Yes | The data array for this dataset. |
+| `active` | `boolean` | Yes | Whether this dataset is currently visible. Only one should be `true`. |
+| `dataVersion` | `Key` | No | Per-dataset version token. Increment when mutating data in place. |
+| `keyExtractor` | `(item, index) => string` | No | Per-dataset key extractor. Falls back to the shared prop. |
+| `estimatedItemSize` | `number` | No | Per-dataset estimated item size. Falls back to the shared prop. |
+| `getEstimatedItemSize` | `(index, item, type) => number` | No | Per-dataset dynamic size estimator. Falls back to the shared prop. |
+| `getFixedItemSize` | `(index, item, type) => number \| undefined` | No | Per-dataset fixed size function. Falls back to the shared prop. |
+| `getItemType` | `(item, index) => string \| undefined` | No | Per-dataset item type function for container recycling. Falls back to the shared prop. |
+
+All other LegendList props (`renderItem`, `recycleItems`, `drawDistance`, `maintainVisibleContentPosition`, etc.) are passed to `LegendListDatasets` directly and shared across all datasets.
+
+---
+
+## 📐 How It Works
+
+### Architecture
+
+```
+Animated.ScrollView (shared)
+├── Header (shared, measured once, size broadcast to all datasets)
+├── DatasetLayer[0] — active:  normal layout flow, receives scroll events
+├── DatasetLayer[1] — inactive: opacity 0, pointer events disabled
+├── DatasetLayer[2] — inactive: opacity 0, pointer events disabled
+└── Footer (shared, measured once, size broadcast to all datasets)
+```
+
+Each `DatasetLayer` is a full, independent LegendList engine wrapped in:
+1. **`StateProvider`** — creates a fresh `StateContext` with its own positions, sizes, container pool, and scroll state
+2. **`React.Activity`** — `mode="visible"` when active, `"hidden"` when inactive (freezes effects, preserves state)
+
+### Scroll Routing
+
+Only the **active** dataset receives scroll events. When the user scrolls, the parent ScrollView captures the offset and routes it to the active layer's `onScrollOffset()`, which updates its internal scroll state and runs `calculateItemsInView`.
+
+Inactive datasets never receive scroll events — they're frozen at whatever state they were in when deactivated.
+
+### Tab Switching
+
+When a new dataset becomes active:
+
+1. Its scroll state is updated to the current scroll offset
+2. `calculateItemsInView` runs — but if the scroll position is still within the previously cached visible range, it **early-returns** and skips all work
+3. The dataset's wrapper style switches from `opacity: 0` to visible
+
+This means switching back to a tab you were just on is nearly free — the containers are already allocated, positioned, and rendered.
+
+### Shared Header & Footer
+
+The `ListHeaderComponent` and `ListFooterComponent` are rendered once in the parent ScrollView. When they're measured, their sizes are broadcast to **every** dataset so each layer's position calculations correctly account for the header/footer offset.
+
+---
+
+## ⚡ Performance Tips
+
+* **Use `estimatedItemSize` or `getEstimatedItemSize`** — Good estimates reduce layout thrash during initial container allocation for each dataset.
+* **Use per-dataset `dataVersion`** — When mutating data in place, increment the specific dataset's `dataVersion` rather than using a shared version. A shared version would trigger rebuilds across ALL datasets simultaneously.
+* **Use per-dataset `keyExtractor`** — If your datasets have different item shapes (e.g., one tab shows orders, another shows trades), provide a per-dataset `keyExtractor` so each dataset resolves keys from the correct field.
+
+---
+
+## ⚠️ Common Footguns
+
+### 1. Multiple datasets with `active: true`
+
+Only one dataset should be active at a time. If multiple are active, only the first active one will receive scroll events and contribute to scroll content size — the others will be in an undefined layout state.
+
+### 2. Forgetting `key` on datasets
+
+Each `DatasetEntry` requires a unique `key`. This is used as the React key for the dataset layer. If keys are duplicated or missing, React will remount layers on every render and you'll lose all the performance benefits.
+
+### 3. Using shared `dataVersion` instead of per-dataset
+
+```tsx
+// ❌ Bad — forces all datasets to rebuild
+<LegendListDatasets
+    dataVersion={globalVersion}
+    datasets={[...]}
+/>
+
+// ✅ Good — only the changed dataset rebuilds
+const datasets = [
+    { key: "recent", data: recentItems, active: true, dataVersion: recentVersion },
+    { key: "popular", data: popularItems, active: false, dataVersion: popularVersion },
+];
+```
+
+### 4. Inline `datasets` array
+
+```tsx
+// ❌ Bad — creates a new array every render, triggers unnecessary re-renders
+<LegendListDatasets
+    datasets={[
+        { key: "a", data: dataA, active: true },
+        { key: "b", data: dataB, active: false },
+    ]}
+/>
+
+// ✅ Good — memoize the datasets array
+const datasets = useMemo(() => [
+    { key: "a", data: dataA, active: activeTab === "a" },
+    { key: "b", data: dataB, active: activeTab === "b" },
+], [dataA, dataB, activeTab]);
+
+<LegendListDatasets datasets={datasets} />
+```
+
+### 5. Deriving data arrays inside `useMemo`
+
+`DatasetLayer` is memoized — it skips re-render when its `data` reference hasn't changed. But if you derive data arrays inside the same `useMemo` that builds the `datasets` array, changing *any* dependency recreates *every* data array:
+
+```tsx
+// ❌ Bad — when activeTab changes, both .filter() calls run and produce new
+// array references, causing ALL dataset layers to re-render
+const datasets = useMemo(() => [
+    { key: "a", data: items.filter(i => i.tab === "a"), active: activeTab === "a" },
+    { key: "b", data: items.filter(i => i.tab === "b"), active: activeTab === "b" },
+], [items, activeTab]);
+
+// ✅ Good — memoize each data array independently so only the one whose
+// source changed gets a new reference
+const dataA = useMemo(() => items.filter(i => i.tab === "a"), [items]);
+const dataB = useMemo(() => items.filter(i => i.tab === "b"), [items]);
+
+const datasets = useMemo(() => [
+    { key: "a", data: dataA, active: activeTab === "a" },
+    { key: "b", data: dataB, active: activeTab === "b" },
+], [dataA, dataB, activeTab]);
+```
+
+Now when `activeTab` changes, `dataA` and `dataB` are the same references — only the `active` booleans change, and the memo on each `DatasetLayer` sees the same `data` prop and skips the re-render.
+
+### 6. Inline `renderItem` and callback props
+
+`LegendListDatasets` stabilizes `renderItem`, `keyExtractor`, `onEndReached`, `onStartReached`, and `onViewableItemsChanged` via refs internally — so un-memoized inline functions won't cause all dataset layers to re-render. However, other callback props should still be memoized with `useCallback` for best performance.
+
+---
+
+## 📚 Full Example
+
+A complete example with a tab bar header and three datasets:
+
+```tsx
+import { useState, useMemo, useCallback } from "react";
+import { View, Text, Pressable, StyleSheet } from "react-native";
+import { LegendListDatasets } from "@legendapp/list";
+import type { DatasetEntry } from "@legendapp/list";
+
+type Item = { id: string; title: string; subtitle: string };
+
+const TabBar = ({ activeTab, onTabChange }: {
+    activeTab: string;
+    onTabChange: (tab: string) => void;
+}) => (
+    <View style={styles.tabBar}>
+        {["recent", "popular", "favorites"].map((tab) => (
+            <Pressable
+                key={tab}
+                onPress={() => onTabChange(tab)}
+                style={[styles.tab, activeTab === tab && styles.activeTab]}
+            >
+                <Text style={[styles.tabText, activeTab === tab && styles.activeTabText]}>
+                    {tab.charAt(0).toUpperCase() + tab.slice(1)}
+                </Text>
+            </Pressable>
+        ))}
+    </View>
+);
+
+export default function DatasetsExample() {
+    const [activeTab, setActiveTab] = useState("recent");
+
+    const datasets: DatasetEntry<Item>[] = useMemo(() => [
+        { key: "recent", data: recentItems, active: activeTab === "recent" },
+        { key: "popular", data: popularItems, active: activeTab === "popular" },
+        { key: "favorites", data: favoriteItems, active: activeTab === "favorites" },
+    ], [activeTab]);
+
+    const renderItem = useCallback(({ item }: { item: Item }) => (
+        <View style={styles.item}>
+            <Text style={styles.title}>{item.title}</Text>
+            <Text style={styles.subtitle}>{item.subtitle}</Text>
+        </View>
+    ), []);
+
+    return (
+        <LegendListDatasets
+            datasets={datasets}
+            renderItem={renderItem}
+            keyExtractor={(item) => item.id}
+            estimatedItemSize={72}
+            recycleItems
+            ListHeaderComponent={
+                <View>
+                    <Text style={styles.heading}>My App</Text>
+                    <TabBar activeTab={activeTab} onTabChange={setActiveTab} />
+                </View>
+            }
+        />
+    );
+}
+```
+
+---
+
+## 🔌 API Reference
+
+`LegendListDatasets` accepts all `LegendList` props except `data` and `children`, plus:
+
+| Prop | Type | Description |
+|------|------|-------------|
+| `datasets` | `DatasetEntry<T>[]` | Array of dataset entries. Each has its own `key`, `data`, and `active` flag. |
+| `renderItem` | `(props) => ReactNode` | Shared render function for all datasets. Receives `LegendListRenderItemProps` with an optional item type. |
+
+The imperative ref (`LegendListRef`) delegates all methods to the **active** dataset — `scrollToIndex`, `scrollToEnd`, `getState`, etc. all operate on whichever dataset is currently active.

--- a/DATASETS.md
+++ b/DATASETS.md
@@ -116,7 +116,7 @@ The `ListHeaderComponent` and `ListFooterComponent` are rendered once in the par
 ## ⚡ Performance Tips
 
 * **Use `estimatedItemSize` or `getEstimatedItemSize`** — Good estimates reduce layout thrash during initial container allocation for each dataset.
-* **Use per-dataset `dataVersion`** — When mutating data in place, increment the specific dataset's `dataVersion` rather than using a shared version. A shared version would trigger rebuilds across ALL datasets simultaneously.
+* **Use per-dataset `dataVersion`** — If you mutate a data array in place (same reference), increment that dataset's `dataVersion` to force LegendList to detect the change.
 * **Use per-dataset `keyExtractor`** — If your datasets have different item shapes (e.g., one tab shows orders, another shows trades), provide a per-dataset `keyExtractor` so each dataset resolves keys from the correct field.
 
 ---
@@ -131,23 +131,7 @@ Only one dataset should be active at a time. If multiple are active, only the fi
 
 Each `DatasetEntry` requires a unique `key`. This is used as the React key for the dataset layer. If keys are duplicated or missing, React will remount layers on every render and you'll lose all the performance benefits.
 
-### 3. Using shared `dataVersion` instead of per-dataset
-
-```tsx
-// ❌ Bad — forces all datasets to rebuild
-<LegendListDatasets
-    dataVersion={globalVersion}
-    datasets={[...]}
-/>
-
-// ✅ Good — only the changed dataset rebuilds
-const datasets = [
-    { key: "recent", data: recentItems, active: true, dataVersion: recentVersion },
-    { key: "popular", data: popularItems, active: false, dataVersion: popularVersion },
-];
-```
-
-### 4. Inline `datasets` array
+### 3. Inline `datasets` array
 
 ```tsx
 // ❌ Bad — creates a new array every render, triggers unnecessary re-renders
@@ -167,7 +151,7 @@ const datasets = useMemo(() => [
 <LegendListDatasets datasets={datasets} />
 ```
 
-### 5. Deriving data arrays inside `useMemo`
+### 4. Deriving data arrays inside `useMemo`
 
 `DatasetLayer` is memoized — it skips re-render when its `data` reference hasn't changed. But if you derive data arrays inside the same `useMemo` that builds the `datasets` array, changing *any* dependency recreates *every* data array:
 
@@ -192,7 +176,7 @@ const datasets = useMemo(() => [
 
 Now when `activeTab` changes, `dataA` and `dataB` are the same references — only the `active` booleans change, and the memo on each `DatasetLayer` sees the same `data` prop and skips the re-render.
 
-### 6. Inline `renderItem` and callback props
+### 5. Inline `renderItem` and callback props
 
 `LegendListDatasets` stabilizes `renderItem`, `keyExtractor`, `onEndReached`, `onStartReached`, and `onViewableItemsChanged` via refs internally — so un-memoized inline functions won't cause all dataset layers to re-render. However, other callback props should still be memoized with `useCallback` for best performance.
 

--- a/example/app/(tabs)/index.tsx
+++ b/example/app/(tabs)/index.tsx
@@ -152,6 +152,10 @@ const data: ListElement[] = [
         title: "Chat keyboard big",
         url: "/chat-keyboard-big",
     },
+    {
+        title: "Datasets (tabbed lists)",
+        url: "/datasets",
+    },
 ].map(
     (v, i) =>
         ({

--- a/example/app/datasets/index.tsx
+++ b/example/app/datasets/index.tsx
@@ -1,0 +1,239 @@
+import { useCallback, useMemo, useState } from "react";
+import { Pressable, StatusBar, StyleSheet, Text, View } from "react-native";
+import { SafeAreaProvider, SafeAreaView } from "react-native-safe-area-context";
+
+import { LegendListDatasets } from "@legendapp/list";
+import type { DatasetEntry } from "@legendapp/list";
+import { countries, getEmojiFlag, type TCountryCode } from "countries-list";
+
+export const unstable_settings = {
+    initialRouteName: "index",
+};
+
+type Country = {
+    id: string;
+    name: string;
+    flag: string;
+    continent: string;
+};
+
+// Convert countries object to array with continent info
+const ALL_COUNTRIES: Country[] = Object.entries(countries)
+    .map(([code, country]) => ({
+        continent: country.continent,
+        flag: getEmojiFlag(code as TCountryCode),
+        id: code,
+        name: country.name,
+    }))
+    .sort((a, b) => a.name.localeCompare(b.name));
+
+// Split into datasets by continent
+const CONTINENT_NAMES: Record<string, string> = {
+    AF: "Africa",
+    AN: "Antarctica",
+    AS: "Asia",
+    EU: "Europe",
+    NA: "North America",
+    OC: "Oceania",
+    SA: "South America",
+};
+
+const TABS = ["All", "EU", "AS", "NA", "AF"] as const;
+type Tab = (typeof TABS)[number];
+
+const DATASETS: Record<Tab, Country[]> = {
+    AF: ALL_COUNTRIES.filter((c) => c.continent === "AF"),
+    AS: ALL_COUNTRIES.filter((c) => c.continent === "AS"),
+    All: ALL_COUNTRIES,
+    EU: ALL_COUNTRIES.filter((c) => c.continent === "EU"),
+    NA: ALL_COUNTRIES.filter((c) => c.continent === "NA"),
+};
+
+const TAB_LABELS: Record<Tab, string> = {
+    AF: "Africa",
+    AS: "Asia",
+    All: "All",
+    EU: "Europe",
+    NA: "N. America",
+};
+
+const TabBar = ({ activeTab, onTabChange }: { activeTab: Tab; onTabChange: (tab: Tab) => void }) => (
+    <View style={styles.tabBar}>
+        {TABS.map((tab) => (
+            <Pressable
+                key={tab}
+                onPress={() => onTabChange(tab)}
+                style={[styles.tab, activeTab === tab && styles.activeTab]}
+            >
+                <Text style={[styles.tabText, activeTab === tab && styles.activeTabText]}>
+                    {TAB_LABELS[tab]}
+                </Text>
+                <Text style={[styles.tabCount, activeTab === tab && styles.activeTabCount]}>
+                    {DATASETS[tab].length}
+                </Text>
+            </Pressable>
+        ))}
+    </View>
+);
+
+const CountryItem = ({ item }: { item: Country }) => (
+    <View style={styles.item}>
+        <View style={styles.flagContainer}>
+            <Text style={styles.flag}>{item.flag}</Text>
+        </View>
+        <View style={styles.contentContainer}>
+            <Text style={styles.title}>
+                {item.name}
+                <Text style={styles.countryCode}> ({item.id})</Text>
+            </Text>
+            <Text style={styles.continent}>{CONTINENT_NAMES[item.continent] ?? item.continent}</Text>
+        </View>
+    </View>
+);
+
+const App = () => {
+    const [activeTab, setActiveTab] = useState<Tab>("All");
+
+    const datasets: DatasetEntry<Country>[] = useMemo(
+        () =>
+            TABS.map((tab) => ({
+                active: activeTab === tab,
+                data: DATASETS[tab],
+                key: tab,
+            })),
+        [activeTab],
+    );
+
+    const renderItem = useCallback(({ item }: { item: Country }) => <CountryItem item={item} />, []);
+
+    const keyExtractor = useCallback((item: Country) => item.id, []);
+
+    return (
+        <SafeAreaProvider>
+            <SafeAreaView style={styles.container}>
+                <LegendListDatasets
+                    datasets={datasets}
+                    estimatedItemSize={60}
+                    keyExtractor={keyExtractor}
+                    ListHeaderComponent={
+                        <View>
+                            <View style={styles.header}>
+                                <Text style={styles.heading}>Countries by Continent</Text>
+                                <Text style={styles.subheading}>
+                                    Datasets demo — {ALL_COUNTRIES.length} countries across {TABS.length} tabs
+                                </Text>
+                            </View>
+                            <TabBar activeTab={activeTab} onTabChange={setActiveTab} />
+                        </View>
+                    }
+                    recycleItems
+                    renderItem={renderItem}
+                />
+            </SafeAreaView>
+        </SafeAreaProvider>
+    );
+};
+
+export default App;
+
+const styles = StyleSheet.create({
+    activeTab: {
+        backgroundColor: "#1976d2",
+        borderColor: "#1976d2",
+    },
+    activeTabCount: {
+        color: "rgba(255, 255, 255, 0.8)",
+    },
+    activeTabText: {
+        color: "#fff",
+        fontWeight: "600",
+    },
+    container: {
+        backgroundColor: "#f5f5f5",
+        flex: 1,
+        marginTop: StatusBar.currentHeight || 0,
+    },
+    contentContainer: {
+        flex: 1,
+        justifyContent: "center",
+    },
+    continent: {
+        color: "#999",
+        fontSize: 13,
+        marginTop: 1,
+    },
+    countryCode: {
+        color: "#666",
+        fontSize: 14,
+        fontWeight: "400",
+    },
+    flag: {
+        fontSize: 28,
+    },
+    flagContainer: {
+        alignItems: "center",
+        backgroundColor: "#f8f9fa",
+        borderRadius: 20,
+        height: 40,
+        justifyContent: "center",
+        marginRight: 16,
+        width: 40,
+    },
+    header: {
+        backgroundColor: "#fff",
+        paddingHorizontal: 16,
+        paddingTop: 16,
+        paddingBottom: 12,
+    },
+    heading: {
+        color: "#333",
+        fontSize: 22,
+        fontWeight: "700",
+    },
+    item: {
+        alignItems: "center",
+        backgroundColor: "#fff",
+        borderRadius: 12,
+        flexDirection: "row",
+        marginHorizontal: 8,
+        marginVertical: 2,
+        paddingHorizontal: 16,
+        paddingVertical: 8,
+    },
+    subheading: {
+        color: "#999",
+        fontSize: 14,
+        marginTop: 4,
+    },
+    tab: {
+        alignItems: "center",
+        borderColor: "#ddd",
+        borderRadius: 20,
+        borderWidth: 1,
+        paddingHorizontal: 14,
+        paddingVertical: 8,
+    },
+    tabBar: {
+        backgroundColor: "#fff",
+        borderBottomColor: "#e0e0e0",
+        borderBottomWidth: 1,
+        flexDirection: "row",
+        gap: 8,
+        paddingBottom: 12,
+        paddingHorizontal: 16,
+    },
+    tabCount: {
+        color: "#999",
+        fontSize: 11,
+        marginTop: 2,
+    },
+    tabText: {
+        color: "#666",
+        fontSize: 14,
+    },
+    title: {
+        color: "#333",
+        fontSize: 16,
+        fontWeight: "500",
+    },
+});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@legendapp/list",
-    "version": "2.0.18",
+    "version": "2.0.19",
     "description": "Legend List is a drop-in replacement for FlatList with much better performance and supporting dynamically sized items.",
     "sideEffects": false,
     "private": false,

--- a/src/components/DatasetLayer.tsx
+++ b/src/components/DatasetLayer.tsx
@@ -18,8 +18,8 @@ import { updateItemSize } from "@/core/updateItemSize";
 import { useWrapIfItem } from "@/core/useWrapIfItem";
 import { setupViewability } from "@/core/viewability";
 import { type StateContext, StateProvider, set$, useStateContext } from "@/state/state";
-import type { InternalState, LegendListDatasetsProps, ScrollIndexWithOffset } from "@/types";
-import { typedForwardRef } from "@/types";
+import type { DatasetEntry, InternalState, LegendListDatasetsProps, ScrollIndexWithOffset } from "@/types";
+import { typedForwardRef, typedMemo } from "@/types";
 import { checkAtBottom } from "@/utils/checkAtBottom";
 import { checkAtTop } from "@/utils/checkAtTop";
 import { createColumnWrapperStyle } from "@/utils/createColumnWrapperStyle";
@@ -53,10 +53,13 @@ export interface DatasetLayerHandle {
 }
 
 // Props for the inner headless layer — shared props from LegendListDatasetsProps
-// plus the per-dataset data and the parent scroll ref
+// plus the per-dataset data/dataVersion and the parent scroll ref.
+// Note: dataVersion here is the PER-DATASET version from DatasetEntry, not the
+// shared prop — this prevents a shared bump from rebuilding all datasets at once.
 export type DatasetLayerProps<T> = Omit<
     LegendListDatasetsProps<T>,
     | "datasets"
+    | "dataVersion"
     | "ListHeaderComponent"
     | "ListHeaderComponentStyle"
     | "ListFooterComponent"
@@ -66,6 +69,7 @@ export type DatasetLayerProps<T> = Omit<
     | "style"
 > & {
     data: ReadonlyArray<T>;
+    dataVersion?: DatasetEntry<T>["dataVersion"];
     refScroller: React.RefObject<ScrollView>;
 };
 
@@ -371,16 +375,21 @@ const DatasetLayerInner = typedForwardRef(function DatasetLayerInner<T>(
     );
 });
 
-export const DatasetLayer = typedForwardRef(function DatasetLayer<T>(
-    props: DatasetLayerProps<T> & { active: boolean },
-    ref: ForwardedRef<DatasetLayerHandle>,
-) {
-    const { active, ...rest } = props;
-    return (
-        <StateProvider>
-            <Activity mode={active ? "visible" : "hidden"}>
-                <DatasetLayerInner ref={ref} {...(rest as DatasetLayerProps<T>)} />
-            </Activity>
-        </StateProvider>
-    );
-});
+// Memoized so that when LegendListDatasets re-renders (e.g. because the active
+// dataset's data changed), sibling DatasetLayers whose data and active flag
+// haven't changed are skipped entirely.
+export const DatasetLayer = typedMemo(
+    typedForwardRef(function DatasetLayer<T>(
+        props: DatasetLayerProps<T> & { active: boolean },
+        ref: ForwardedRef<DatasetLayerHandle>,
+    ) {
+        const { active, ...rest } = props;
+        return (
+            <StateProvider>
+                <Activity mode={active ? "visible" : "hidden"}>
+                    <DatasetLayerInner ref={ref} {...(rest as DatasetLayerProps<T>)} />
+                </Activity>
+            </StateProvider>
+        );
+    }),
+);

--- a/src/components/DatasetLayer.tsx
+++ b/src/components/DatasetLayer.tsx
@@ -1,0 +1,342 @@
+// biome-ignore lint/style/useImportType: Leaving this out makes it crash in some environments
+
+import type { ForwardedRef } from "react";
+import * as React from "react";
+import { useCallback, useEffect, useImperativeHandle, useLayoutEffect, useMemo, useRef } from "react";
+import { Dimensions, type LayoutRectangle, type ScrollView } from "react-native";
+
+import { Containers } from "@/components/Containers";
+import { IsNewArchitecture } from "@/constants";
+import { calculateItemsInView } from "@/core/calculateItemsInView";
+import { checkResetContainers } from "@/core/checkResetContainers";
+import { doInitialAllocateContainers } from "@/core/doInitialAllocateContainers";
+import { handleLayout } from "@/core/handleLayout";
+import { ScrollAdjustHandler } from "@/core/ScrollAdjustHandler";
+import { updateItemPositions } from "@/core/updateItemPositions";
+import { updateItemSize } from "@/core/updateItemSize";
+import { useWrapIfItem } from "@/core/useWrapIfItem";
+import { setupViewability } from "@/core/viewability";
+import { StateProvider, set$, useStateContext } from "@/state/state";
+import type { InternalState, LegendListDatasetsProps } from "@/types";
+import { typedForwardRef } from "@/types";
+import { checkAtBottom } from "@/utils/checkAtBottom";
+import { checkAtTop } from "@/utils/checkAtTop";
+import { createColumnWrapperStyle } from "@/utils/createColumnWrapperStyle";
+import { getId } from "@/utils/getId";
+import { getRenderedItem } from "@/utils/getRenderedItem";
+import { setPaddingTop } from "@/utils/setPaddingTop";
+
+const DEFAULT_DRAW_DISTANCE = 250;
+const DEFAULT_ITEM_SIZE = 100;
+
+// React.Activity is stable in React 19 but may not be in @types/react yet
+const Activity = (React as any).Activity as React.ComponentType<{
+    mode: "visible" | "hidden";
+    children: React.ReactNode;
+}>;
+
+export interface DatasetLayerHandle {
+    /** Route a scroll offset to this dataset (only called for active dataset) */
+    onScrollOffset: (offset: number) => void;
+    /** Propagate viewport layout from the parent ScrollView */
+    setViewportLayout: (layout: LayoutRectangle) => void;
+    /** Propagate the shared header size to this dataset's ctx */
+    setHeaderSize: (size: number) => void;
+    /** Called when this dataset switches from inactive → active */
+    activate: (scrollOffset: number) => void;
+}
+
+// Props for the inner headless layer — shared props from LegendListDatasetsProps
+// plus the per-dataset data and the parent scroll ref
+export type DatasetLayerProps<T> = Omit<
+    LegendListDatasetsProps<T>,
+    | "datasets"
+    | "ListHeaderComponent"
+    | "ListHeaderComponentStyle"
+    | "ListFooterComponent"
+    | "ListFooterComponentStyle"
+    | "onLayout"
+    | "refScrollView"
+    | "style"
+> & {
+    data: ReadonlyArray<T>;
+    refScroller: React.RefObject<ScrollView>;
+};
+
+const DatasetLayerInner = typedForwardRef(function DatasetLayerInner<T>(
+    props: DatasetLayerProps<T>,
+    ref: ForwardedRef<DatasetLayerHandle>,
+) {
+    const {
+        alignItemsAtEnd = false,
+        columnWrapperStyle,
+        contentContainerStyle: contentContainerStyleProp,
+        data: dataProp = [],
+        dataVersion,
+        drawDistance = DEFAULT_DRAW_DISTANCE,
+        enableAverages = true,
+        estimatedItemSize: estimatedItemSizeProp,
+        estimatedListSize,
+        extraData,
+        getEstimatedItemSize,
+        getFixedItemSize,
+        getItemType,
+        horizontal,
+        initialContainerPoolRatio = 2,
+        initialHeaderSize,
+        itemsAreEqual,
+        keyExtractor: keyExtractorProp,
+        maintainScrollAtEnd = false,
+        maintainScrollAtEndThreshold = 0.1,
+        maintainVisibleContentPosition = true,
+        numColumns: numColumnsProp = 1,
+        onEndReached,
+        onEndReachedThreshold = 0.5,
+        onItemSizeChanged,
+        onLoad,
+        onStartReached,
+        onStartReachedThreshold = 0.5,
+        onStickyHeaderChange,
+        onViewableItemsChanged,
+        recycleItems = false,
+        refScroller,
+        renderItem,
+        snapToIndices,
+        stickyIndices,
+        suggestEstimatedItemSize,
+        viewabilityConfig,
+        viewabilityConfigCallbackPairs,
+        waitForInitialLayout,
+        stickyHeaderConfig,
+        ItemSeparatorComponent,
+    } = props;
+
+    const ctx = useStateContext();
+    if (initialHeaderSize !== undefined && !ctx.internalState) {
+        ctx.values.set("headerSize", initialHeaderSize);
+    }
+    ctx.columnWrapperStyle =
+        columnWrapperStyle ||
+        (contentContainerStyleProp ? createColumnWrapperStyle(contentContainerStyleProp as any) : undefined);
+
+    const estimatedItemSize = estimatedItemSizeProp ?? DEFAULT_ITEM_SIZE;
+    const scrollBuffer = (drawDistance ?? DEFAULT_DRAW_DISTANCE) || 1;
+    const keyExtractor = keyExtractorProp ?? ((_item: any, index: number) => index.toString());
+
+    const refState = useRef<InternalState>();
+
+    if (!refState.current) {
+        if (!ctx.internalState) {
+            const initialScrollLength = (estimatedListSize ??
+                (IsNewArchitecture ? { height: 0, width: 0 } : Dimensions.get("window")))[
+                horizontal ? "width" : "height"
+            ];
+
+            ctx.internalState = {
+                activeStickyIndex: undefined,
+                averageSizes: {},
+                columns: new Map(),
+                containerItemKeys: new Set(),
+                containerItemTypes: new Map(),
+                dataChangeNeedsScrollUpdate: false,
+                enableScrollForNextCalculateItemsInView: true,
+                endBuffered: -1,
+                endNoBuffer: -1,
+                endReachedBlockedByTimer: false,
+                firstFullyOnScreenIndex: -1,
+                idCache: [],
+                idsInView: [],
+                indexByKey: new Map(),
+                initialScroll: undefined,
+                isAtEnd: false,
+                isAtStart: false,
+                isEndReached: false,
+                isStartReached: false,
+                lastBatchingAction: Date.now(),
+                lastLayout: undefined,
+                loadStartTime: Date.now(),
+                minIndexSizeChanged: 0,
+                nativeMarginTop: 0,
+                positions: new Map(),
+                props: {} as any,
+                queuedCalculateItemsInView: 0,
+                refScroller: undefined as any,
+                scroll: 0,
+                scrollAdjustHandler: new ScrollAdjustHandler(ctx),
+                scrollForNextCalculateItemsInView: undefined,
+                scrollHistory: [],
+                scrollLength: initialScrollLength,
+                scrollPending: 0,
+                scrollPrev: 0,
+                scrollPrevTime: 0,
+                scrollProcessingEnabled: true,
+                scrollTime: 0,
+                sizes: new Map(),
+                sizesKnown: new Map(),
+                startBuffered: -1,
+                startNoBuffer: -1,
+                startReachedBlockedByTimer: false,
+                stickyContainerPool: new Set(),
+                stickyContainers: new Map(),
+                timeoutSizeMessage: 0,
+                timeouts: new Set(),
+                totalSize: 0,
+                viewabilityConfigCallbackPairs: undefined as never,
+            };
+
+            set$(ctx, "maintainVisibleContentPosition", maintainVisibleContentPosition);
+            set$(ctx, "extraData", extraData);
+        }
+        refState.current = ctx.internalState;
+    }
+
+    const state = refState.current!;
+    const isFirst = !state.props.renderItem;
+
+    const didDataChange = state.props.dataVersion !== dataVersion || state.props.data !== dataProp;
+    if (didDataChange) {
+        state.dataChangeNeedsScrollUpdate = true;
+    }
+
+    state.props = {
+        alignItemsAtEnd,
+        data: dataProp,
+        dataVersion,
+        enableAverages,
+        estimatedItemSize,
+        getEstimatedItemSize: useWrapIfItem(getEstimatedItemSize),
+        getFixedItemSize: useWrapIfItem(getFixedItemSize),
+        getItemType: useWrapIfItem(getItemType),
+        horizontal: !!horizontal,
+        initialContainerPoolRatio,
+        initialScroll: undefined,
+        itemsAreEqual,
+        keyExtractor: useWrapIfItem(keyExtractor),
+        maintainScrollAtEnd,
+        maintainScrollAtEndThreshold,
+        maintainVisibleContentPosition,
+        numColumns: numColumnsProp,
+        onEndReached,
+        onEndReachedThreshold,
+        onItemSizeChanged,
+        onLoad,
+        onScroll: undefined,
+        onStartReached,
+        onStartReachedThreshold,
+        onStickyHeaderChange,
+        recycleItems: !!recycleItems,
+        renderItem: renderItem!,
+        scrollBuffer,
+        snapToIndices,
+        stickyIndicesArr: stickyIndices ?? [],
+        stickyIndicesSet: useMemo(() => new Set(stickyIndices ?? []), [stickyIndices?.join(",")]),
+        stylePaddingBottom: 0,
+        stylePaddingTop: 0,
+        suggestEstimatedItemSize: !!suggestEstimatedItemSize,
+    };
+
+    state.refScroller = refScroller;
+
+    const memoizedLastItemKeys = useMemo(() => {
+        if (!dataProp.length) return [];
+        return Array.from({ length: Math.min(numColumnsProp, dataProp.length) }, (_, i) =>
+            getId(state, dataProp.length - 1 - i),
+        );
+    }, [dataProp, dataVersion, numColumnsProp]);
+
+    const initializeStateVars = useCallback(() => {
+        set$(ctx, "lastItemKeys", memoizedLastItemKeys);
+        set$(ctx, "numColumns", numColumnsProp);
+        setPaddingTop(ctx, state, { stylePaddingTop: 0 });
+    }, [memoizedLastItemKeys, numColumnsProp]);
+
+    if (isFirst) {
+        initializeStateVars();
+        updateItemPositions(ctx, state, /*dataChanged*/ true);
+    }
+
+    useLayoutEffect(() => {
+        const didAllocateContainers = dataProp.length > 0 && doInitialAllocateContainers(ctx, state);
+        if (!didAllocateContainers) {
+            checkResetContainers(ctx, state, isFirst, dataProp);
+        }
+    }, [dataProp, dataVersion, numColumnsProp]);
+
+    useLayoutEffect(() => {
+        set$(ctx, "extraData", extraData);
+    }, [extraData]);
+
+    useLayoutEffect(initializeStateVars, [dataVersion, memoizedLastItemKeys.join(","), numColumnsProp]);
+
+    useEffect(() => {
+        const viewability = setupViewability({
+            onViewableItemsChanged,
+            viewabilityConfig,
+            viewabilityConfigCallbackPairs,
+        });
+        state.viewabilityConfigCallbackPairs = viewability;
+        state.enableScrollForNextCalculateItemsInView = !viewability;
+    }, [viewabilityConfig, viewabilityConfigCallbackPairs, onViewableItemsChanged]);
+
+    useImperativeHandle(
+        ref,
+        () => ({
+            activate(scrollOffset: number) {
+                state.scroll = scrollOffset;
+                state.dataChangeNeedsScrollUpdate = true;
+                state.scrollForNextCalculateItemsInView = undefined;
+                calculateItemsInView(ctx, state, { dataChanged: false, doMVCP: false });
+            },
+            onScrollOffset(offset: number) {
+                state.scroll = offset;
+                state.lastBatchingAction = Date.now();
+                state.dataChangeNeedsScrollUpdate = false;
+                calculateItemsInView(ctx, state);
+                checkAtBottom(ctx, state);
+                checkAtTop(state);
+            },
+            setHeaderSize(size: number) {
+                set$(ctx, "headerSize", size);
+            },
+            setViewportLayout(layout: LayoutRectangle) {
+                handleLayout(ctx, state, layout, () => {});
+            },
+        }),
+        [],
+    );
+
+    const fns = useMemo(
+        () => ({
+            getRenderedItem: (key: string) => getRenderedItem(ctx, state, key),
+            updateItemSize: (itemKey: string, sizeObj: { width: number; height: number }) =>
+                updateItemSize(ctx, state, itemKey, sizeObj),
+        }),
+        [],
+    );
+
+    return (
+        <Containers
+            getRenderedItem={fns.getRenderedItem}
+            horizontal={!!horizontal}
+            ItemSeparatorComponent={ItemSeparatorComponent}
+            recycleItems={!!recycleItems}
+            stickyHeaderConfig={stickyHeaderConfig}
+            updateItemSize={fns.updateItemSize}
+            waitForInitialLayout={waitForInitialLayout}
+        />
+    );
+});
+
+export const DatasetLayer = typedForwardRef(function DatasetLayer<T>(
+    props: DatasetLayerProps<T> & { active: boolean },
+    ref: ForwardedRef<DatasetLayerHandle>,
+) {
+    const { active, ...rest } = props;
+    return (
+        <StateProvider>
+            <Activity mode={active ? "visible" : "hidden"}>
+                <DatasetLayerInner ref={ref} {...(rest as DatasetLayerProps<T>)} />
+            </Activity>
+        </StateProvider>
+    );
+});

--- a/src/components/DatasetLayer.tsx
+++ b/src/components/DatasetLayer.tsx
@@ -12,12 +12,13 @@ import { checkResetContainers } from "@/core/checkResetContainers";
 import { doInitialAllocateContainers } from "@/core/doInitialAllocateContainers";
 import { handleLayout } from "@/core/handleLayout";
 import { ScrollAdjustHandler } from "@/core/ScrollAdjustHandler";
+import { scrollToIndex } from "@/core/scrollToIndex";
 import { updateItemPositions } from "@/core/updateItemPositions";
 import { updateItemSize } from "@/core/updateItemSize";
 import { useWrapIfItem } from "@/core/useWrapIfItem";
 import { setupViewability } from "@/core/viewability";
-import { StateProvider, set$, useStateContext } from "@/state/state";
-import type { InternalState, LegendListDatasetsProps } from "@/types";
+import { type StateContext, StateProvider, set$, useStateContext } from "@/state/state";
+import type { InternalState, LegendListDatasetsProps, ScrollIndexWithOffset } from "@/types";
 import { typedForwardRef } from "@/types";
 import { checkAtBottom } from "@/utils/checkAtBottom";
 import { checkAtTop } from "@/utils/checkAtTop";
@@ -25,6 +26,7 @@ import { createColumnWrapperStyle } from "@/utils/createColumnWrapperStyle";
 import { getId } from "@/utils/getId";
 import { getRenderedItem } from "@/utils/getRenderedItem";
 import { setPaddingTop } from "@/utils/setPaddingTop";
+import { updateSnapToOffsets } from "@/utils/updateSnapToOffsets";
 
 const DEFAULT_DRAW_DISTANCE = 250;
 const DEFAULT_ITEM_SIZE = 100;
@@ -44,6 +46,10 @@ export interface DatasetLayerHandle {
     setHeaderSize: (size: number) => void;
     /** Called when this dataset switches from inactive → active */
     activate: (scrollOffset: number) => void;
+    /** Access to the StateContext for ref delegation */
+    getCtx: () => StateContext;
+    /** Access to the InternalState for ref delegation */
+    getState: () => InternalState;
 }
 
 // Props for the inner headless layer — shared props from LegendListDatasetsProps
@@ -84,6 +90,8 @@ const DatasetLayerInner = typedForwardRef(function DatasetLayerInner<T>(
         horizontal,
         initialContainerPoolRatio = 2,
         initialHeaderSize,
+        initialScrollIndex: initialScrollIndexProp,
+        initialScrollOffset: initialScrollOffsetProp,
         itemsAreEqual,
         keyExtractor: keyExtractorProp,
         maintainScrollAtEnd = false,
@@ -110,6 +118,17 @@ const DatasetLayerInner = typedForwardRef(function DatasetLayerInner<T>(
         stickyHeaderConfig,
         ItemSeparatorComponent,
     } = props;
+
+    // Build initialScroll the same way LegendListInner does
+    const initialScroll: ScrollIndexWithOffset | undefined =
+        initialScrollIndexProp || initialScrollOffsetProp
+            ? typeof initialScrollIndexProp === "object"
+                ? { index: initialScrollIndexProp.index || 0, viewOffset: initialScrollIndexProp.viewOffset || 0 }
+                : { index: initialScrollIndexProp || 0, viewOffset: initialScrollOffsetProp || 0 }
+            : undefined;
+
+    // Track whether we've applied the initial scroll for this dataset
+    const hasAppliedInitialScrollRef = useRef(false);
 
     const ctx = useStateContext();
     if (initialHeaderSize !== undefined && !ctx.internalState) {
@@ -147,7 +166,7 @@ const DatasetLayerInner = typedForwardRef(function DatasetLayerInner<T>(
                 idCache: [],
                 idsInView: [],
                 indexByKey: new Map(),
-                initialScroll: undefined,
+                initialScroll,
                 isAtEnd: false,
                 isAtStart: false,
                 isEndReached: false,
@@ -198,6 +217,9 @@ const DatasetLayerInner = typedForwardRef(function DatasetLayerInner<T>(
         state.dataChangeNeedsScrollUpdate = true;
     }
 
+    // Keep initialScroll in sync with props so calculateItemsInView uses it correctly
+    state.initialScroll = initialScroll;
+
     state.props = {
         alignItemsAtEnd,
         data: dataProp,
@@ -209,7 +231,7 @@ const DatasetLayerInner = typedForwardRef(function DatasetLayerInner<T>(
         getItemType: useWrapIfItem(getItemType),
         horizontal: !!horizontal,
         initialContainerPoolRatio,
-        initialScroll: undefined,
+        initialScroll,
         itemsAreEqual,
         keyExtractor: useWrapIfItem(keyExtractor),
         maintainScrollAtEnd,
@@ -263,6 +285,12 @@ const DatasetLayerInner = typedForwardRef(function DatasetLayerInner<T>(
     }, [dataProp, dataVersion, numColumnsProp]);
 
     useLayoutEffect(() => {
+        if (snapToIndices) {
+            updateSnapToOffsets(ctx, state);
+        }
+    }, [snapToIndices]);
+
+    useLayoutEffect(() => {
         set$(ctx, "extraData", extraData);
     }, [extraData]);
 
@@ -282,10 +310,26 @@ const DatasetLayerInner = typedForwardRef(function DatasetLayerInner<T>(
         ref,
         () => ({
             activate(scrollOffset: number) {
-                state.scroll = scrollOffset;
+                // Apply initialScroll the first time this dataset becomes active
+                if (initialScroll && !hasAppliedInitialScrollRef.current) {
+                    hasAppliedInitialScrollRef.current = true;
+                    scrollToIndex(ctx, state, {
+                        animated: false,
+                        index: initialScroll.index,
+                        viewOffset: initialScroll.viewOffset,
+                    });
+                } else {
+                    state.scroll = scrollOffset;
+                }
                 state.dataChangeNeedsScrollUpdate = true;
                 state.scrollForNextCalculateItemsInView = undefined;
                 calculateItemsInView(ctx, state, { dataChanged: false, doMVCP: false });
+            },
+            getCtx() {
+                return ctx;
+            },
+            getState() {
+                return state;
             },
             onScrollOffset(offset: number) {
                 state.scroll = offset;

--- a/src/components/DatasetLayer.tsx
+++ b/src/components/DatasetLayer.tsx
@@ -1,9 +1,7 @@
-// biome-ignore lint/style/useImportType: Leaving this out makes it crash in some environments
-
 import type { ForwardedRef } from "react";
 import * as React from "react";
 import { useCallback, useEffect, useImperativeHandle, useLayoutEffect, useMemo, useRef } from "react";
-import { Dimensions, type LayoutRectangle, type ScrollView } from "react-native";
+import { type Animated, Dimensions, type LayoutRectangle, Platform, type ScrollView } from "react-native";
 
 import { Containers } from "@/components/Containers";
 import { IsNewArchitecture } from "@/constants";
@@ -17,25 +15,19 @@ import { updateItemPositions } from "@/core/updateItemPositions";
 import { updateItemSize } from "@/core/updateItemSize";
 import { useWrapIfItem } from "@/core/useWrapIfItem";
 import { setupViewability } from "@/core/viewability";
-import { type StateContext, StateProvider, set$, useStateContext } from "@/state/state";
+import { peek$, type StateContext, StateProvider, set$, useStateContext } from "@/state/state";
 import type { DatasetEntry, InternalState, LegendListDatasetsProps, ScrollIndexWithOffset } from "@/types";
 import { typedForwardRef, typedMemo } from "@/types";
 import { checkAtBottom } from "@/utils/checkAtBottom";
 import { checkAtTop } from "@/utils/checkAtTop";
-import { createColumnWrapperStyle } from "@/utils/createColumnWrapperStyle";
 import { getId } from "@/utils/getId";
 import { getRenderedItem } from "@/utils/getRenderedItem";
+import { requestAdjust } from "@/utils/requestAdjust";
 import { setPaddingTop } from "@/utils/setPaddingTop";
 import { updateSnapToOffsets } from "@/utils/updateSnapToOffsets";
 
 const DEFAULT_DRAW_DISTANCE = 250;
 const DEFAULT_ITEM_SIZE = 100;
-
-// React.Activity is stable in React 19 but may not be in @types/react yet
-const Activity = (React as any).Activity as React.ComponentType<{
-    mode: "visible" | "hidden";
-    children: React.ReactNode;
-}>;
 
 export interface DatasetLayerHandle {
     /** Route a scroll offset to this dataset (only called for active dataset) */
@@ -44,6 +36,8 @@ export interface DatasetLayerHandle {
     setViewportLayout: (layout: LayoutRectangle) => void;
     /** Propagate the shared header size to this dataset's ctx */
     setHeaderSize: (size: number) => void;
+    /** Propagate the shared footer size to this dataset's ctx */
+    setFooterSize: (size: number) => void;
     /** Called when this dataset switches from inactive → active */
     activate: (scrollOffset: number) => void;
     /** Access to the StateContext for ref delegation */
@@ -68,9 +62,12 @@ export type DatasetLayerProps<T> = Omit<
     | "refScrollView"
     | "style"
 > & {
+    animatedScrollY: Animated.Value;
     data: ReadonlyArray<T>;
     dataVersion?: DatasetEntry<T>["dataVersion"];
     refScroller: React.RefObject<ScrollView>;
+    stylePaddingBottom: number;
+    stylePaddingTop: number;
 };
 
 const DatasetLayerInner = typedForwardRef(function DatasetLayerInner<T>(
@@ -79,8 +76,8 @@ const DatasetLayerInner = typedForwardRef(function DatasetLayerInner<T>(
 ) {
     const {
         alignItemsAtEnd = false,
+        animatedScrollY,
         columnWrapperStyle,
-        contentContainerStyle: contentContainerStyleProp,
         data: dataProp = [],
         dataVersion,
         drawDistance = DEFAULT_DRAW_DISTANCE,
@@ -114,6 +111,8 @@ const DatasetLayerInner = typedForwardRef(function DatasetLayerInner<T>(
         refScroller,
         renderItem,
         snapToIndices,
+        stylePaddingBottom,
+        stylePaddingTop,
         stickyIndices,
         suggestEstimatedItemSize,
         viewabilityConfig,
@@ -138,9 +137,8 @@ const DatasetLayerInner = typedForwardRef(function DatasetLayerInner<T>(
     if (initialHeaderSize !== undefined && !ctx.internalState) {
         ctx.values.set("headerSize", initialHeaderSize);
     }
-    ctx.columnWrapperStyle =
-        columnWrapperStyle ||
-        (contentContainerStyleProp ? createColumnWrapperStyle(contentContainerStyleProp as any) : undefined);
+    ctx.animatedScrollY = animatedScrollY;
+    ctx.columnWrapperStyle = columnWrapperStyle;
 
     const estimatedItemSize = estimatedItemSizeProp ?? DEFAULT_ITEM_SIZE;
     const scrollBuffer = (drawDistance ?? DEFAULT_DRAW_DISTANCE) || 1;
@@ -256,8 +254,8 @@ const DatasetLayerInner = typedForwardRef(function DatasetLayerInner<T>(
         snapToIndices,
         stickyIndicesArr: stickyIndices ?? [],
         stickyIndicesSet: useMemo(() => new Set(stickyIndices ?? []), [stickyIndices?.join(",")]),
-        stylePaddingBottom: 0,
-        stylePaddingTop: 0,
+        stylePaddingBottom,
+        stylePaddingTop,
         suggestEstimatedItemSize: !!suggestEstimatedItemSize,
     };
 
@@ -273,8 +271,18 @@ const DatasetLayerInner = typedForwardRef(function DatasetLayerInner<T>(
     const initializeStateVars = useCallback(() => {
         set$(ctx, "lastItemKeys", memoizedLastItemKeys);
         set$(ctx, "numColumns", numColumnsProp);
-        setPaddingTop(ctx, state, { stylePaddingTop: 0 });
-    }, [memoizedLastItemKeys, numColumnsProp]);
+        const prevPaddingTop = peek$(ctx, "stylePaddingTop");
+        setPaddingTop(ctx, state, { stylePaddingTop });
+        refState.current!.props.stylePaddingBottom = stylePaddingBottom;
+
+        let paddingDiff = stylePaddingTop - prevPaddingTop;
+        if (maintainVisibleContentPosition && paddingDiff && prevPaddingTop !== undefined && Platform.OS === "ios") {
+            if (state.scroll < 0) {
+                paddingDiff += state.scroll;
+            }
+            requestAdjust(ctx, state, paddingDiff);
+        }
+    }, [maintainVisibleContentPosition, memoizedLastItemKeys, numColumnsProp, stylePaddingBottom, stylePaddingTop]);
 
     if (isFirst) {
         initializeStateVars();
@@ -298,7 +306,13 @@ const DatasetLayerInner = typedForwardRef(function DatasetLayerInner<T>(
         set$(ctx, "extraData", extraData);
     }, [extraData]);
 
-    useLayoutEffect(initializeStateVars, [dataVersion, memoizedLastItemKeys.join(","), numColumnsProp]);
+    useLayoutEffect(initializeStateVars, [
+        dataVersion,
+        memoizedLastItemKeys.join(","),
+        numColumnsProp,
+        stylePaddingBottom,
+        stylePaddingTop,
+    ]);
 
     useEffect(() => {
         const viewability = setupViewability({
@@ -309,6 +323,15 @@ const DatasetLayerInner = typedForwardRef(function DatasetLayerInner<T>(
         state.viewabilityConfigCallbackPairs = viewability;
         state.enableScrollForNextCalculateItemsInView = !viewability;
     }, [viewabilityConfig, viewabilityConfigCallbackPairs, onViewableItemsChanged]);
+
+    useEffect(() => {
+        const timeout = setTimeout(() => {
+            state.scrollAdjustHandler.setMounted();
+        }, 0);
+        return () => {
+            clearTimeout(timeout);
+        };
+    }, []);
 
     useImperativeHandle(
         ref,
@@ -343,6 +366,9 @@ const DatasetLayerInner = typedForwardRef(function DatasetLayerInner<T>(
                 checkAtBottom(ctx, state);
                 checkAtTop(state);
             },
+            setFooterSize(size: number) {
+                set$(ctx, "footerSize", size);
+            },
             setHeaderSize(size: number) {
                 set$(ctx, "headerSize", size);
             },
@@ -374,6 +400,12 @@ const DatasetLayerInner = typedForwardRef(function DatasetLayerInner<T>(
         />
     );
 });
+
+// React.Activity is stable in React 19 but may not be in @types/react yet
+const Activity = (React as any).Activity as React.ComponentType<{
+    mode: "visible" | "hidden";
+    children: React.ReactNode;
+}>;
 
 // Memoized so that when LegendListDatasets re-renders (e.g. because the active
 // dataset's data changed), sibling DatasetLayers whose data and active flag

--- a/src/components/DatasetLayer.tsx
+++ b/src/components/DatasetLayer.tsx
@@ -348,8 +348,8 @@ const DatasetLayerInner = typedForwardRef(function DatasetLayerInner<T>(
                 } else {
                     state.scroll = scrollOffset;
                 }
-                state.dataChangeNeedsScrollUpdate = true;
-                state.scrollForNextCalculateItemsInView = undefined;
+                // Don't clear scrollForNextCalculateItemsInView — let calculateItemsInView
+                // use the cached range to early-return if scroll hasn't moved enough.
                 calculateItemsInView(ctx, state, { dataChanged: false, doMVCP: false });
             },
             getCtx() {
@@ -401,11 +401,24 @@ const DatasetLayerInner = typedForwardRef(function DatasetLayerInner<T>(
     );
 });
 
-// React.Activity is stable in React 19 but may not be in @types/react yet
-const Activity = (React as any).Activity as React.ComponentType<{
+// React.Activity is stable in React 19 but may not be in @types/react yet.
+// Fall back to a plain passthrough when unavailable (e.g. React 18 / old-arch).
+const Activity = (React as any).Activity as
+    | React.ComponentType<{ mode: "visible" | "hidden"; children: React.ReactNode }>
+    | undefined;
+
+function ActivityOrFragment({
+    mode,
+    children,
+}: {
     mode: "visible" | "hidden";
     children: React.ReactNode;
-}>;
+}) {
+    if (Activity) {
+        return <Activity mode={mode}>{children}</Activity>;
+    }
+    return <>{children}</>;
+}
 
 // Memoized so that when LegendListDatasets re-renders (e.g. because the active
 // dataset's data changed), sibling DatasetLayers whose data and active flag
@@ -418,9 +431,9 @@ export const DatasetLayer = typedMemo(
         const { active, ...rest } = props;
         return (
             <StateProvider>
-                <Activity mode={active ? "visible" : "hidden"}>
+                <ActivityOrFragment mode={active ? "visible" : "hidden"}>
                     <DatasetLayerInner ref={ref} {...(rest as DatasetLayerProps<T>)} />
-                </Activity>
+                </ActivityOrFragment>
             </StateProvider>
         );
     }),

--- a/src/components/DatasetLayer.tsx
+++ b/src/components/DatasetLayer.tsx
@@ -48,12 +48,9 @@ export interface DatasetLayerHandle {
 
 // Props for the inner headless layer — shared props from LegendListDatasetsProps
 // plus the per-dataset data/dataVersion and the parent scroll ref.
-// Note: dataVersion here is the PER-DATASET version from DatasetEntry, not the
-// shared prop — this prevents a shared bump from rebuilding all datasets at once.
 export type DatasetLayerProps<T> = Omit<
     LegendListDatasetsProps<T>,
     | "datasets"
-    | "dataVersion"
     | "ListHeaderComponent"
     | "ListHeaderComponentStyle"
     | "ListFooterComponent"
@@ -90,7 +87,6 @@ const DatasetLayerInner = typedForwardRef(function DatasetLayerInner<T>(
         getItemType,
         horizontal,
         initialContainerPoolRatio = 2,
-        initialHeaderSize,
         initialScrollIndex: initialScrollIndexProp,
         initialScrollOffset: initialScrollOffsetProp,
         itemsAreEqual,
@@ -134,9 +130,6 @@ const DatasetLayerInner = typedForwardRef(function DatasetLayerInner<T>(
     const hasAppliedInitialScrollRef = useRef(false);
 
     const ctx = useStateContext();
-    if (initialHeaderSize !== undefined && !ctx.internalState) {
-        ctx.values.set("headerSize", initialHeaderSize);
-    }
     ctx.animatedScrollY = animatedScrollY;
     ctx.columnWrapperStyle = columnWrapperStyle;
 

--- a/src/components/LegendListDatasets.tsx
+++ b/src/components/LegendListDatasets.tsx
@@ -1,6 +1,5 @@
-// biome-ignore lint/style/useImportType: Leaving this out makes it crash in some environments
-import * as React from "react";
 import type { ForwardedRef } from "react";
+import * as React from "react";
 import { useCallback, useEffect, useImperativeHandle, useLayoutEffect, useMemo, useRef, useState } from "react";
 import {
     Animated,
@@ -16,15 +15,19 @@ import {
 
 import { DatasetLayer, type DatasetLayerHandle } from "@/components/DatasetLayer";
 import { LayoutView } from "@/components/LayoutView";
+import { IsNewArchitecture } from "@/constants";
+import { finishScrollTo } from "@/core/finishScrollTo";
 import { scrollTo } from "@/core/scrollTo";
 import { scrollToIndex } from "@/core/scrollToIndex";
 import { useCombinedRef } from "@/hooks/useCombinedRef";
 import { useOnLayoutSync } from "@/hooks/useOnLayoutSync";
-import { listen$, peek$, set$ } from "@/state/state";
+import { listen$, peek$, type StateContext, set$ } from "@/state/state";
 import type { LegendListDatasetsProps, LegendListRef, ScrollState } from "@/types";
 import { typedForwardRef, typedMemo } from "@/types";
+import { createColumnWrapperStyle } from "@/utils/createColumnWrapperStyle";
 import { getComponent } from "@/utils/getComponent";
 import { getId } from "@/utils/getId";
+import { extractPadding } from "@/utils/helpers";
 
 // Style applied to wrapper of each inactive dataset layer so it takes no layout space
 // and its contents (items at translateY: -9999) don't bleed into the visible area.
@@ -39,6 +42,49 @@ const INACTIVE_LAYER_STYLE = StyleSheet.create({
     },
 }).wrapper;
 
+function useLayerValue(
+    ctx: StateContext | undefined,
+    key: "alignItemsPaddingTop" | "scrollAdjust" | "scrollAdjustUserOffset",
+) {
+    const [value, setValue] = useState(() => (ctx ? (peek$(ctx, key) ?? 0) : 0));
+
+    useEffect(() => {
+        if (!ctx) {
+            setValue(0);
+            return;
+        }
+
+        setValue(peek$(ctx, key) ?? 0);
+        return listen$(ctx, key, (next) => setValue(next ?? 0));
+    }, [ctx, key]);
+
+    return value;
+}
+
+function ActivePadding({ ctx }: { ctx: StateContext | undefined }) {
+    const paddingTop = useLayerValue(ctx, "alignItemsPaddingTop");
+    return <View style={{ paddingTop }} />;
+}
+
+function ActiveScrollAdjust({ ctx, horizontal }: { ctx: StateContext | undefined; horizontal: boolean }) {
+    const bias = 10_000_000;
+    const scrollAdjust = useLayerValue(ctx, "scrollAdjust");
+    const scrollAdjustUserOffset = useLayerValue(ctx, "scrollAdjustUserOffset");
+    const scrollOffset = scrollAdjust + scrollAdjustUserOffset + bias;
+
+    return (
+        <View
+            style={{
+                height: 0,
+                left: horizontal ? scrollOffset : 0,
+                position: "absolute",
+                top: horizontal ? 0 : scrollOffset,
+                width: 0,
+            }}
+        />
+    );
+}
+
 export const LegendListDatasets = typedMemo(
     typedForwardRef(function LegendListDatasets<T>(
         props: LegendListDatasetsProps<T>,
@@ -49,7 +95,7 @@ export const LegendListDatasets = typedMemo(
             renderItem,
             alignItemsAtEnd,
             columnWrapperStyle,
-            contentContainerStyle,
+            contentContainerStyle: contentContainerStyleProp,
             dataVersion: _dataVersion, // per-dataset via DatasetEntry.dataVersion; destructured to exclude from ...rest
             drawDistance,
             enableAverages,
@@ -107,6 +153,7 @@ export const LegendListDatasets = typedMemo(
 
         const refScroller = useRef<ScrollView>(null);
         const combinedRef = useCombinedRef(refScroller, refScrollView);
+        const sharedAnimatedScrollY = useRef(new Animated.Value(0)).current;
 
         // Track current scroll offset so we can pass it to a newly-activated dataset
         const currentScrollRef = useRef(0);
@@ -120,6 +167,28 @@ export const LegendListDatasets = typedMemo(
         activeIndexRef.current = activeIndex;
 
         const prevActiveIndexRef = useRef(activeIndex);
+        const [activeCtx, setActiveCtx] = useState<StateContext | undefined>(undefined);
+
+        const contentContainerStyle = useMemo(
+            () => ({ ...(StyleSheet.flatten(contentContainerStyleProp) || {}) }),
+            [contentContainerStyleProp],
+        );
+        const style = useMemo(() => ({ ...(StyleSheet.flatten(styleProp) || {}) }), [styleProp]);
+        const resolvedColumnWrapperStyle = useMemo(
+            () => columnWrapperStyle || createColumnWrapperStyle(contentContainerStyle),
+            [columnWrapperStyle, contentContainerStyle],
+        );
+        const stylePaddingTopState = extractPadding(style, contentContainerStyle, "Top");
+        const stylePaddingBottomState = extractPadding(style, contentContainerStyle, "Bottom");
+
+        const getActiveLayer = useCallback(() => {
+            const index = activeIndexRef.current;
+            return index >= 0 ? layerRefs.current[index] : undefined;
+        }, []);
+
+        const getActiveCtx = useCallback(() => getActiveLayer()?.getCtx(), [getActiveLayer]);
+
+        const getActiveState = useCallback(() => getActiveLayer()?.getState(), [getActiveLayer]);
 
         // When active dataset changes, tell the newly active layer to catch up
         useLayoutEffect(() => {
@@ -130,7 +199,11 @@ export const LegendListDatasets = typedMemo(
             }
         }, [activeIndex]);
 
-        const onScrollHandler = useCallback(
+        useEffect(() => {
+            setActiveCtx(getActiveCtx());
+        }, [activeIndex, getActiveCtx]);
+
+        const onScrollListener = useCallback(
             (event: NativeSyntheticEvent<NativeScrollEvent>) => {
                 const offset = event.nativeEvent.contentOffset[horizontal ? "x" : "y"];
                 currentScrollRef.current = offset;
@@ -142,6 +215,19 @@ export const LegendListDatasets = typedMemo(
             },
             [horizontal, onScrollProp],
         );
+
+        const onScrollHandler = useMemo(() => {
+            if (stickyIndices?.length) {
+                return Animated.event(
+                    [{ nativeEvent: { contentOffset: { [horizontal ? "x" : "y"]: sharedAnimatedScrollY } } }],
+                    {
+                        listener: onScrollListener,
+                        useNativeDriver: true,
+                    },
+                );
+            }
+            return onScrollListener;
+        }, [horizontal, onScrollListener, sharedAnimatedScrollY, stickyIndices?.length]);
 
         const onLayoutChange = useCallback((layout: LayoutRectangle) => {
             // Propagate viewport size to ALL layers so each can allocate containers
@@ -166,31 +252,32 @@ export const LegendListDatasets = typedMemo(
             [horizontal],
         );
 
+        const onLayoutFooter = useCallback(
+            (rect: LayoutRectangle) => {
+                const size = rect[horizontal ? "width" : "height"];
+                for (const ref of layerRefs.current) {
+                    ref?.setFooterSize(size);
+                }
+            },
+            [horizontal],
+        );
+
         // Subscribe to the active dataset's snapToOffsets so the ScrollView stays in sync
         const [snapOffsets, setSnapOffsets] = useState<number[] | undefined>(undefined);
         useEffect(() => {
+            const ctx = getActiveCtx();
+            setActiveCtx(ctx);
             if (!snapToIndices) {
                 setSnapOffsets(undefined);
                 return;
             }
-            const activeLayer = layerRefs.current[activeIndex];
-            if (!activeLayer) return;
-            const ctx = activeLayer.getCtx();
+            if (!ctx) return;
             setSnapOffsets(peek$(ctx, "snapToOffsets"));
             return listen$(ctx, "snapToOffsets", setSnapOffsets);
-        }, [activeIndex, snapToIndices]);
+        }, [activeIndex, getActiveCtx, snapToIndices]);
 
         // Wire up the imperative ref — delegates to the active dataset's ctx/state
         useImperativeHandle(forwardedRef, () => {
-            const getActiveCtx = () => {
-                const layer = layerRefs.current[activeIndexRef.current];
-                return layer?.getCtx();
-            };
-            const getActiveState = () => {
-                const layer = layerRefs.current[activeIndexRef.current];
-                return layer?.getState();
-            };
-
             const scrollIndexIntoView = (options: Parameters<LegendListRef["scrollIndexIntoView"]>[0]) => {
                 const ctx = getActiveCtx();
                 const state = getActiveState();
@@ -242,10 +329,11 @@ export const LegendListDatasets = typedMemo(
                     if (!ctx || !state) return;
                     const index = state.props.data.length - 1;
                     if (index !== -1) {
+                        const paddingBottom = state.props.stylePaddingBottom || 0;
                         const footerSize = peek$(ctx, "footerSize") || 0;
                         scrollToIndex(ctx, state, {
                             index,
-                            viewOffset: -footerSize + (options?.viewOffset || 0),
+                            viewOffset: -paddingBottom - footerSize + (options?.viewOffset || 0),
                             viewPosition: 1,
                             ...options,
                         });
@@ -278,7 +366,27 @@ export const LegendListDatasets = typedMemo(
                     set$(ctx, "scrollAdjustUserOffset", val);
                 },
             };
-        }, []);
+        }, [getActiveCtx, getActiveState]);
+
+        const onMomentumScrollEndHandler = useCallback(
+            (event: NativeSyntheticEvent<NativeScrollEvent>) => {
+                const finishActiveScroll = () => {
+                    const state = getActiveState();
+                    if (state) {
+                        finishScrollTo(state);
+                    }
+                };
+
+                if (IsNewArchitecture) {
+                    requestAnimationFrame(finishActiveScroll);
+                } else {
+                    setTimeout(finishActiveScroll, 1000);
+                }
+
+                onMomentumScrollEnd?.(event);
+            },
+            [getActiveState, onMomentumScrollEnd],
+        );
 
         // Stabilize callbacks via refs so that un-memoized inline functions in the
         // parent don't invalidate sharedLayerProps and re-render all dataset layers.
@@ -316,7 +424,8 @@ export const LegendListDatasets = typedMemo(
         const sharedLayerProps = useMemo(
             () => ({
                 alignItemsAtEnd,
-                columnWrapperStyle,
+                animatedScrollY: sharedAnimatedScrollY,
+                columnWrapperStyle: resolvedColumnWrapperStyle,
                 contentContainerStyle,
                 drawDistance,
                 enableAverages,
@@ -351,6 +460,8 @@ export const LegendListDatasets = typedMemo(
                 snapToIndices,
                 stickyHeaderConfig,
                 stickyIndices,
+                stylePaddingBottom: stylePaddingBottomState,
+                stylePaddingTop: stylePaddingTopState,
                 suggestEstimatedItemSize,
                 viewabilityConfig,
                 viewabilityConfigCallbackPairs,
@@ -358,7 +469,6 @@ export const LegendListDatasets = typedMemo(
             }),
             [
                 alignItemsAtEnd,
-                columnWrapperStyle,
                 contentContainerStyle,
                 drawDistance,
                 enableAverages,
@@ -385,7 +495,11 @@ export const LegendListDatasets = typedMemo(
                 onStartReachedThreshold,
                 onStickyHeaderChange,
                 recycleItems,
+                resolvedColumnWrapperStyle,
+                sharedAnimatedScrollY,
                 snapToIndices,
+                stylePaddingBottomState,
+                stylePaddingTopState,
                 stickyHeaderConfig,
                 stickyIndices,
                 suggestEstimatedItemSize,
@@ -395,28 +509,31 @@ export const LegendListDatasets = typedMemo(
             ],
         );
 
-        const style = styleProp ? StyleSheet.flatten(styleProp) : undefined;
-
         const activeDataset = activeIndex >= 0 ? datasets[activeIndex] : undefined;
         const showEmpty = ListEmptyComponent && activeDataset && activeDataset.data.length === 0;
 
         return (
             <Animated.ScrollView
                 {...rest}
-                contentContainerStyle={contentContainerStyle}
+                contentContainerStyle={[contentContainerStyle, horizontal ? { height: "100%" } : {}]}
                 horizontal={horizontal}
                 maintainVisibleContentPosition={maintainVisibleContentPosition ? { minIndexForVisible: 0 } : undefined}
                 onLayout={onLayout}
-                onMomentumScrollEnd={onMomentumScrollEnd}
+                onMomentumScrollEnd={onMomentumScrollEndHandler}
                 onScroll={onScrollHandler}
                 ref={combinedRef}
                 refreshControl={
                     refreshControl
-                        ? refreshControl
+                        ? stylePaddingTopState > 0
+                            ? React.cloneElement(refreshControl, {
+                                  progressViewOffset:
+                                      (refreshControl.props.progressViewOffset || 0) + stylePaddingTopState,
+                              })
+                            : refreshControl
                         : onRefresh && (
                               <RefreshControl
                                   onRefresh={onRefresh}
-                                  progressViewOffset={progressViewOffset}
+                                  progressViewOffset={(progressViewOffset || 0) + stylePaddingTopState}
                                   refreshing={!!refreshing}
                               />
                           )
@@ -425,6 +542,8 @@ export const LegendListDatasets = typedMemo(
                 snapToOffsets={snapOffsets}
                 style={style}
             >
+                {maintainVisibleContentPosition && <ActiveScrollAdjust ctx={activeCtx} horizontal={!!horizontal} />}
+                <ActivePadding ctx={activeCtx} />
                 {ListHeaderComponent && (
                     <LayoutView onLayoutChange={onLayoutHeader} style={ListHeaderComponentStyle}>
                         {getComponent(ListHeaderComponent)}
@@ -439,6 +558,13 @@ export const LegendListDatasets = typedMemo(
                                 active={dataset.active}
                                 data={dataset.data}
                                 dataVersion={dataset.dataVersion}
+                                estimatedItemSize={dataset.estimatedItemSize ?? sharedLayerProps.estimatedItemSize}
+                                getEstimatedItemSize={
+                                    dataset.getEstimatedItemSize ?? sharedLayerProps.getEstimatedItemSize
+                                }
+                                getFixedItemSize={dataset.getFixedItemSize ?? sharedLayerProps.getFixedItemSize}
+                                getItemType={dataset.getItemType ?? sharedLayerProps.getItemType}
+                                keyExtractor={dataset.keyExtractor ?? sharedLayerProps.keyExtractor}
                                 ref={(handle: DatasetLayerHandle | null) => {
                                     layerRefs.current[index] = handle;
                                 }}
@@ -447,7 +573,9 @@ export const LegendListDatasets = typedMemo(
                         </View>
                     ))}
                 {ListFooterComponent && (
-                    <View style={ListFooterComponentStyle}>{getComponent(ListFooterComponent)}</View>
+                    <LayoutView onLayoutChange={onLayoutFooter} style={ListFooterComponentStyle}>
+                        {getComponent(ListFooterComponent)}
+                    </LayoutView>
                 )}
             </Animated.ScrollView>
         );

--- a/src/components/LegendListDatasets.tsx
+++ b/src/components/LegendListDatasets.tsx
@@ -96,7 +96,6 @@ export const LegendListDatasets = typedMemo(
             alignItemsAtEnd,
             columnWrapperStyle,
             contentContainerStyle: contentContainerStyleProp,
-            dataVersion: _dataVersion, // per-dataset via DatasetEntry.dataVersion; destructured to exclude from ...rest
             drawDistance,
             enableAverages,
             estimatedItemSize,
@@ -107,7 +106,6 @@ export const LegendListDatasets = typedMemo(
             getItemType,
             horizontal,
             initialContainerPoolRatio,
-            initialHeaderSize,
             initialScrollIndex,
             initialScrollOffset,
             itemsAreEqual,
@@ -420,7 +418,6 @@ export const LegendListDatasets = typedMemo(
 
         // Structural/layout props that legitimately need to re-propagate when changed.
         // Callbacks are excluded — they're stabilized via refs above.
-        // dataVersion is excluded — it's per-dataset via DatasetEntry.dataVersion.
         const sharedLayerProps = useMemo(
             () => ({
                 alignItemsAtEnd,
@@ -438,7 +435,6 @@ export const LegendListDatasets = typedMemo(
                 horizontal,
                 ItemSeparatorComponent,
                 initialContainerPoolRatio,
-                initialHeaderSize,
                 initialScrollIndex,
                 initialScrollOffset,
                 itemsAreEqual,
@@ -481,7 +477,6 @@ export const LegendListDatasets = typedMemo(
                 horizontal,
                 ItemSeparatorComponent,
                 initialContainerPoolRatio,
-                initialHeaderSize,
                 initialScrollIndex,
                 initialScrollOffset,
                 itemsAreEqual,

--- a/src/components/LegendListDatasets.tsx
+++ b/src/components/LegendListDatasets.tsx
@@ -1,0 +1,305 @@
+// biome-ignore lint/style/useImportType: Leaving this out makes it crash in some environments
+import * as React from "react";
+import type { ForwardedRef } from "react";
+import { useCallback, useLayoutEffect, useMemo, useRef } from "react";
+import {
+    Animated,
+    type LayoutRectangle,
+    type NativeScrollEvent,
+    type NativeSyntheticEvent,
+    Platform,
+    RefreshControl,
+    type ScrollView,
+    StyleSheet,
+    View,
+} from "react-native";
+
+import { DatasetLayer, type DatasetLayerHandle } from "@/components/DatasetLayer";
+import { LayoutView } from "@/components/LayoutView";
+import { useCombinedRef } from "@/hooks/useCombinedRef";
+import { useOnLayoutSync } from "@/hooks/useOnLayoutSync";
+import type { LegendListDatasetsProps, LegendListRef } from "@/types";
+import { typedForwardRef, typedMemo } from "@/types";
+import { getComponent } from "@/utils/getComponent";
+
+// Style applied to wrapper of each inactive dataset layer so it takes no layout space
+// and its contents (items at translateY: -9999) don't bleed into the visible area.
+const INACTIVE_LAYER_STYLE = StyleSheet.create({
+    wrapper: {
+        height: 0,
+        left: 0,
+        overflow: "hidden",
+        position: "absolute",
+        right: 0,
+        top: 0,
+    },
+}).wrapper;
+
+export const LegendListDatasets = typedMemo(
+    typedForwardRef(function LegendListDatasets<T>(
+        props: LegendListDatasetsProps<T>,
+        _forwardedRef: ForwardedRef<LegendListRef>,
+    ) {
+        const {
+            datasets,
+            renderItem,
+            drawDistance,
+            enableAverages,
+            estimatedItemSize,
+            estimatedListSize,
+            extraData,
+            getEstimatedItemSize,
+            getFixedItemSize,
+            getItemType,
+            horizontal,
+            initialContainerPoolRatio,
+            initialHeaderSize,
+            itemsAreEqual,
+            keyExtractor,
+            ListEmptyComponent,
+            ListHeaderComponent,
+            ListHeaderComponentStyle,
+            ListFooterComponent,
+            ListFooterComponentStyle,
+            maintainScrollAtEnd,
+            maintainScrollAtEndThreshold,
+            maintainVisibleContentPosition,
+            numColumns,
+            onEndReached,
+            onEndReachedThreshold,
+            onItemSizeChanged,
+            onLayout: onLayoutProp,
+            onLoad,
+            onMomentumScrollEnd,
+            onRefresh,
+            onScroll: onScrollProp,
+            onStartReached,
+            onStartReachedThreshold,
+            onStickyHeaderChange,
+            onViewableItemsChanged,
+            progressViewOffset,
+            recycleItems,
+            refreshControl,
+            refreshing,
+            refScrollView,
+            scrollEventThrottle,
+            snapToIndices,
+            stickyIndices,
+            style: styleProp,
+            suggestEstimatedItemSize,
+            viewabilityConfig,
+            viewabilityConfigCallbackPairs,
+            waitForInitialLayout,
+            stickyHeaderConfig,
+            ItemSeparatorComponent,
+            columnWrapperStyle,
+            contentContainerStyle,
+            dataVersion,
+            alignItemsAtEnd,
+            ...rest
+        } = props;
+
+        const refScroller = useRef<ScrollView>(null);
+        const combinedRef = useCombinedRef(refScroller, refScrollView);
+
+        // Track current scroll offset so we can pass it to a newly-activated dataset
+        const currentScrollRef = useRef(0);
+
+        // One ref slot per dataset, indexed by position
+        const layerRefs = useRef<Array<DatasetLayerHandle | null>>([]);
+
+        const activeIndex = datasets.findIndex((d) => d.active);
+        const prevActiveIndexRef = useRef(activeIndex);
+
+        // When active dataset changes, tell the newly active layer to catch up
+        useLayoutEffect(() => {
+            const prev = prevActiveIndexRef.current;
+            prevActiveIndexRef.current = activeIndex;
+            if (prev !== activeIndex && activeIndex >= 0) {
+                layerRefs.current[activeIndex]?.activate(currentScrollRef.current);
+            }
+        }, [activeIndex]);
+
+        const onScrollHandler = useCallback(
+            (event: NativeSyntheticEvent<NativeScrollEvent>) => {
+                const offset = event.nativeEvent.contentOffset[horizontal ? "x" : "y"];
+                currentScrollRef.current = offset;
+                if (activeIndex >= 0) {
+                    layerRefs.current[activeIndex]?.onScrollOffset(offset);
+                }
+                onScrollProp?.(event);
+            },
+            [activeIndex, horizontal, onScrollProp],
+        );
+
+        const onLayoutChange = useCallback((layout: LayoutRectangle) => {
+            // Propagate viewport size to ALL layers so each can allocate containers
+            for (const ref of layerRefs.current) {
+                ref?.setViewportLayout({
+                    height: layout.height,
+                    width: layout.width,
+                    x: 0,
+                    y: 0,
+                });
+            }
+        }, []);
+
+        const { onLayout } = useOnLayoutSync({
+            onLayoutChange,
+            onLayoutProp,
+            ref: refScroller as unknown as React.RefObject<View>,
+        });
+
+        const onLayoutHeader = useCallback(
+            (rect: LayoutRectangle) => {
+                const size = rect[horizontal ? "width" : "height"];
+                // All layers need the same header size for correct scroll calculations
+                for (const ref of layerRefs.current) {
+                    ref?.setHeaderSize(size);
+                }
+            },
+            [horizontal],
+        );
+
+        // Shared props forwarded to every DatasetLayer
+        const sharedLayerProps = useMemo(
+            () => ({
+                alignItemsAtEnd,
+                columnWrapperStyle,
+                contentContainerStyle,
+                dataVersion,
+                drawDistance,
+                enableAverages,
+                estimatedItemSize,
+                estimatedListSize,
+                extraData,
+                getEstimatedItemSize,
+                getFixedItemSize,
+                getItemType,
+                horizontal,
+                ItemSeparatorComponent,
+                initialContainerPoolRatio,
+                initialHeaderSize,
+                itemsAreEqual,
+                keyExtractor,
+                maintainScrollAtEnd,
+                maintainScrollAtEndThreshold,
+                maintainVisibleContentPosition,
+                numColumns,
+                onEndReached,
+                onEndReachedThreshold,
+                onItemSizeChanged,
+                onLoad,
+                onStartReached,
+                onStartReachedThreshold,
+                onStickyHeaderChange,
+                onViewableItemsChanged,
+                recycleItems,
+                renderItem,
+                snapToIndices,
+                stickyHeaderConfig,
+                stickyIndices,
+                suggestEstimatedItemSize,
+                viewabilityConfig,
+                viewabilityConfigCallbackPairs,
+                waitForInitialLayout,
+            }),
+            [
+                alignItemsAtEnd,
+                columnWrapperStyle,
+                contentContainerStyle,
+                dataVersion,
+                drawDistance,
+                enableAverages,
+                estimatedItemSize,
+                estimatedListSize,
+                extraData,
+                getEstimatedItemSize,
+                getFixedItemSize,
+                getItemType,
+                horizontal,
+                initialContainerPoolRatio,
+                initialHeaderSize,
+                ItemSeparatorComponent,
+                itemsAreEqual,
+                keyExtractor,
+                maintainScrollAtEnd,
+                maintainScrollAtEndThreshold,
+                maintainVisibleContentPosition,
+                numColumns,
+                onEndReached,
+                onEndReachedThreshold,
+                onItemSizeChanged,
+                onLoad,
+                onStartReached,
+                onStartReachedThreshold,
+                onStickyHeaderChange,
+                onViewableItemsChanged,
+                recycleItems,
+                renderItem,
+                snapToIndices,
+                stickyHeaderConfig,
+                stickyIndices,
+                suggestEstimatedItemSize,
+                viewabilityConfig,
+                viewabilityConfigCallbackPairs,
+                waitForInitialLayout,
+            ],
+        );
+
+        const style = styleProp ? StyleSheet.flatten(styleProp) : undefined;
+
+        const activeDataset = activeIndex >= 0 ? datasets[activeIndex] : undefined;
+        const showEmpty = ListEmptyComponent && activeDataset && activeDataset.data.length === 0;
+
+        return (
+            <Animated.ScrollView
+                {...rest}
+                contentContainerStyle={contentContainerStyle}
+                horizontal={horizontal}
+                maintainVisibleContentPosition={maintainVisibleContentPosition ? { minIndexForVisible: 0 } : undefined}
+                onLayout={onLayout}
+                onMomentumScrollEnd={onMomentumScrollEnd}
+                onScroll={onScrollHandler}
+                ref={combinedRef}
+                refreshControl={
+                    refreshControl
+                        ? refreshControl
+                        : onRefresh && (
+                              <RefreshControl
+                                  onRefresh={onRefresh}
+                                  progressViewOffset={progressViewOffset}
+                                  refreshing={!!refreshing}
+                              />
+                          )
+                }
+                scrollEventThrottle={Platform.OS === "web" ? 16 : scrollEventThrottle}
+                style={style}
+            >
+                {ListHeaderComponent && (
+                    <LayoutView onLayoutChange={onLayoutHeader} style={ListHeaderComponentStyle}>
+                        {getComponent(ListHeaderComponent)}
+                    </LayoutView>
+                )}
+                {showEmpty && getComponent(ListEmptyComponent)}
+                {!showEmpty &&
+                    datasets.map((dataset, index) => (
+                        <View key={dataset.key} style={dataset.active ? undefined : INACTIVE_LAYER_STYLE}>
+                            <DatasetLayer
+                                {...sharedLayerProps}
+                                active={dataset.active}
+                                data={dataset.data}
+                                ref={(handle: DatasetLayerHandle | null) => {
+                                    layerRefs.current[index] = handle;
+                                }}
+                                refScroller={refScroller}
+                            />
+                        </View>
+                    ))}
+                {ListFooterComponent && (
+                    <View style={ListFooterComponentStyle}>{getComponent(ListFooterComponent)}</View>
+                )}
+            </Animated.ScrollView>
+        );
+    }),
+);

--- a/src/components/LegendListDatasets.tsx
+++ b/src/components/LegendListDatasets.tsx
@@ -29,13 +29,13 @@ import { getComponent } from "@/utils/getComponent";
 import { getId } from "@/utils/getId";
 import { extractPadding } from "@/utils/helpers";
 
-// Style applied to wrapper of each inactive dataset layer so it takes no layout space
-// and its contents (items at translateY: -9999) don't bleed into the visible area.
+// Style applied to wrapper of each inactive dataset layer so it doesn't affect
+// scroll content size while keeping native layout warm for instant reactivation.
 const INACTIVE_LAYER_STYLE = StyleSheet.create({
     wrapper: {
-        height: 0,
         left: 0,
-        overflow: "hidden",
+        opacity: 0,
+        pointerEvents: "none",
         position: "absolute",
         right: 0,
         top: 0,

--- a/src/components/LegendListDatasets.tsx
+++ b/src/components/LegendListDatasets.tsx
@@ -1,7 +1,7 @@
 // biome-ignore lint/style/useImportType: Leaving this out makes it crash in some environments
 import * as React from "react";
 import type { ForwardedRef } from "react";
-import { useCallback, useLayoutEffect, useMemo, useRef } from "react";
+import { useCallback, useEffect, useImperativeHandle, useLayoutEffect, useMemo, useRef, useState } from "react";
 import {
     Animated,
     type LayoutRectangle,
@@ -16,11 +16,15 @@ import {
 
 import { DatasetLayer, type DatasetLayerHandle } from "@/components/DatasetLayer";
 import { LayoutView } from "@/components/LayoutView";
+import { scrollTo } from "@/core/scrollTo";
+import { scrollToIndex } from "@/core/scrollToIndex";
 import { useCombinedRef } from "@/hooks/useCombinedRef";
 import { useOnLayoutSync } from "@/hooks/useOnLayoutSync";
-import type { LegendListDatasetsProps, LegendListRef } from "@/types";
+import { listen$, peek$, set$ } from "@/state/state";
+import type { LegendListDatasetsProps, LegendListRef, ScrollState } from "@/types";
 import { typedForwardRef, typedMemo } from "@/types";
 import { getComponent } from "@/utils/getComponent";
+import { getId } from "@/utils/getId";
 
 // Style applied to wrapper of each inactive dataset layer so it takes no layout space
 // and its contents (items at translateY: -9999) don't bleed into the visible area.
@@ -38,11 +42,15 @@ const INACTIVE_LAYER_STYLE = StyleSheet.create({
 export const LegendListDatasets = typedMemo(
     typedForwardRef(function LegendListDatasets<T>(
         props: LegendListDatasetsProps<T>,
-        _forwardedRef: ForwardedRef<LegendListRef>,
+        forwardedRef: ForwardedRef<LegendListRef>,
     ) {
         const {
             datasets,
             renderItem,
+            alignItemsAtEnd,
+            columnWrapperStyle,
+            contentContainerStyle,
+            dataVersion,
             drawDistance,
             enableAverages,
             estimatedItemSize,
@@ -54,7 +62,10 @@ export const LegendListDatasets = typedMemo(
             horizontal,
             initialContainerPoolRatio,
             initialHeaderSize,
+            initialScrollIndex,
+            initialScrollOffset,
             itemsAreEqual,
+            ItemSeparatorComponent,
             keyExtractor,
             ListEmptyComponent,
             ListHeaderComponent,
@@ -84,18 +95,13 @@ export const LegendListDatasets = typedMemo(
             refScrollView,
             scrollEventThrottle,
             snapToIndices,
+            stickyHeaderConfig,
             stickyIndices,
             style: styleProp,
             suggestEstimatedItemSize,
             viewabilityConfig,
             viewabilityConfigCallbackPairs,
             waitForInitialLayout,
-            stickyHeaderConfig,
-            ItemSeparatorComponent,
-            columnWrapperStyle,
-            contentContainerStyle,
-            dataVersion,
-            alignItemsAtEnd,
             ...rest
         } = props;
 
@@ -109,6 +115,10 @@ export const LegendListDatasets = typedMemo(
         const layerRefs = useRef<Array<DatasetLayerHandle | null>>([]);
 
         const activeIndex = datasets.findIndex((d) => d.active);
+        // Stable ref so imperative handle methods always see the current active index
+        const activeIndexRef = useRef(activeIndex);
+        activeIndexRef.current = activeIndex;
+
         const prevActiveIndexRef = useRef(activeIndex);
 
         // When active dataset changes, tell the newly active layer to catch up
@@ -124,23 +134,19 @@ export const LegendListDatasets = typedMemo(
             (event: NativeSyntheticEvent<NativeScrollEvent>) => {
                 const offset = event.nativeEvent.contentOffset[horizontal ? "x" : "y"];
                 currentScrollRef.current = offset;
-                if (activeIndex >= 0) {
-                    layerRefs.current[activeIndex]?.onScrollOffset(offset);
+                const idx = activeIndexRef.current;
+                if (idx >= 0) {
+                    layerRefs.current[idx]?.onScrollOffset(offset);
                 }
                 onScrollProp?.(event);
             },
-            [activeIndex, horizontal, onScrollProp],
+            [horizontal, onScrollProp],
         );
 
         const onLayoutChange = useCallback((layout: LayoutRectangle) => {
             // Propagate viewport size to ALL layers so each can allocate containers
             for (const ref of layerRefs.current) {
-                ref?.setViewportLayout({
-                    height: layout.height,
-                    width: layout.width,
-                    x: 0,
-                    y: 0,
-                });
+                ref?.setViewportLayout({ height: layout.height, width: layout.width, x: 0, y: 0 });
             }
         }, []);
 
@@ -153,13 +159,126 @@ export const LegendListDatasets = typedMemo(
         const onLayoutHeader = useCallback(
             (rect: LayoutRectangle) => {
                 const size = rect[horizontal ? "width" : "height"];
-                // All layers need the same header size for correct scroll calculations
                 for (const ref of layerRefs.current) {
                     ref?.setHeaderSize(size);
                 }
             },
             [horizontal],
         );
+
+        // Subscribe to the active dataset's snapToOffsets so the ScrollView stays in sync
+        const [snapOffsets, setSnapOffsets] = useState<number[] | undefined>(undefined);
+        useEffect(() => {
+            if (!snapToIndices) {
+                setSnapOffsets(undefined);
+                return;
+            }
+            const activeLayer = layerRefs.current[activeIndex];
+            if (!activeLayer) return;
+            const ctx = activeLayer.getCtx();
+            setSnapOffsets(peek$(ctx, "snapToOffsets"));
+            return listen$(ctx, "snapToOffsets", setSnapOffsets);
+        }, [activeIndex, snapToIndices]);
+
+        // Wire up the imperative ref — delegates to the active dataset's ctx/state
+        useImperativeHandle(forwardedRef, () => {
+            const getActiveCtx = () => {
+                const layer = layerRefs.current[activeIndexRef.current];
+                return layer?.getCtx();
+            };
+            const getActiveState = () => {
+                const layer = layerRefs.current[activeIndexRef.current];
+                return layer?.getState();
+            };
+
+            const scrollIndexIntoView = (options: Parameters<LegendListRef["scrollIndexIntoView"]>[0]) => {
+                const ctx = getActiveCtx();
+                const state = getActiveState();
+                if (!ctx || !state) return;
+                const { index, ...rest } = options;
+                const { startNoBuffer, endNoBuffer } = state;
+                if (index < startNoBuffer || index > endNoBuffer) {
+                    const viewPosition = index < startNoBuffer ? 0 : 1;
+                    scrollToIndex(ctx, state, { ...rest, index, viewPosition });
+                }
+            };
+
+            return {
+                flashScrollIndicators: () => refScroller.current!.flashScrollIndicators(),
+                getNativeScrollRef: () => refScroller.current!,
+                getScrollableNode: () => refScroller.current!.getScrollableNode(),
+                getScrollResponder: () => refScroller.current!.getScrollResponder(),
+                getState: (): ScrollState => {
+                    const state = getActiveState();
+                    if (!state) return {} as ScrollState;
+                    return {
+                        activeStickyIndex: state.activeStickyIndex,
+                        contentLength: state.totalSize,
+                        data: state.props.data,
+                        end: state.endNoBuffer,
+                        endBuffered: state.endBuffered,
+                        isAtEnd: state.isAtEnd,
+                        isAtStart: state.isAtStart,
+                        positionAtIndex: (index: number) => state.positions.get(getId(state, index))!,
+                        positions: state.positions,
+                        scroll: state.scroll,
+                        scrollLength: state.scrollLength,
+                        sizeAtIndex: (index: number) => state.sizesKnown.get(getId(state, index))!,
+                        sizes: state.sizesKnown,
+                        start: state.startNoBuffer,
+                        startBuffered: state.startBuffered,
+                    };
+                },
+                scrollIndexIntoView,
+                scrollItemIntoView: ({ item, ...options }) => {
+                    const state = getActiveState();
+                    if (!state) return;
+                    const index = state.props.data.indexOf(item);
+                    if (index !== -1) scrollIndexIntoView({ index, ...options });
+                },
+                scrollToEnd: (options) => {
+                    const ctx = getActiveCtx();
+                    const state = getActiveState();
+                    if (!ctx || !state) return;
+                    const index = state.props.data.length - 1;
+                    if (index !== -1) {
+                        const footerSize = peek$(ctx, "footerSize") || 0;
+                        scrollToIndex(ctx, state, {
+                            index,
+                            viewOffset: -footerSize + (options?.viewOffset || 0),
+                            viewPosition: 1,
+                            ...options,
+                        });
+                    }
+                },
+                scrollToIndex: (params) => {
+                    const ctx = getActiveCtx();
+                    const state = getActiveState();
+                    if (ctx && state) scrollToIndex(ctx, state, params);
+                },
+                scrollToItem: ({ item, ...options }) => {
+                    const ctx = getActiveCtx();
+                    const state = getActiveState();
+                    if (!ctx || !state) return;
+                    const index = state.props.data.indexOf(item);
+                    if (index !== -1) scrollToIndex(ctx, state, { index, ...options });
+                },
+                scrollToOffset: (params) => {
+                    const state = getActiveState();
+                    if (state) scrollTo(state, params);
+                },
+                setScrollProcessingEnabled: (enabled: boolean) => {
+                    const state = getActiveState();
+                    if (state) state.scrollProcessingEnabled = enabled;
+                },
+                setVisibleContentAnchorOffset: (value: number | ((value: number) => number)) => {
+                    const ctx = getActiveCtx();
+                    if (!ctx) return;
+                    const val = typeof value === "function" ? value(peek$(ctx, "scrollAdjustUserOffset") || 0) : value;
+                    set$(ctx, "scrollAdjustUserOffset", val);
+                },
+            };
+        }, []);
 
         // Shared props forwarded to every DatasetLayer
         const sharedLayerProps = useMemo(
@@ -180,6 +299,8 @@ export const LegendListDatasets = typedMemo(
                 ItemSeparatorComponent,
                 initialContainerPoolRatio,
                 initialHeaderSize,
+                initialScrollIndex,
+                initialScrollOffset,
                 itemsAreEqual,
                 keyExtractor,
                 maintainScrollAtEnd,
@@ -220,6 +341,8 @@ export const LegendListDatasets = typedMemo(
                 horizontal,
                 initialContainerPoolRatio,
                 initialHeaderSize,
+                initialScrollIndex,
+                initialScrollOffset,
                 ItemSeparatorComponent,
                 itemsAreEqual,
                 keyExtractor,
@@ -274,6 +397,7 @@ export const LegendListDatasets = typedMemo(
                           )
                 }
                 scrollEventThrottle={Platform.OS === "web" ? 16 : scrollEventThrottle}
+                snapToOffsets={snapOffsets}
                 style={style}
             >
                 {ListHeaderComponent && (

--- a/src/components/LegendListDatasets.tsx
+++ b/src/components/LegendListDatasets.tsx
@@ -50,7 +50,7 @@ export const LegendListDatasets = typedMemo(
             alignItemsAtEnd,
             columnWrapperStyle,
             contentContainerStyle,
-            dataVersion,
+            dataVersion: _dataVersion, // per-dataset via DatasetEntry.dataVersion; destructured to exclude from ...rest
             drawDistance,
             enableAverages,
             estimatedItemSize,
@@ -280,13 +280,44 @@ export const LegendListDatasets = typedMemo(
             };
         }, []);
 
-        // Shared props forwarded to every DatasetLayer
+        // Stabilize callbacks via refs so that un-memoized inline functions in the
+        // parent don't invalidate sharedLayerProps and re-render all dataset layers.
+        const renderItemRef = useRef(renderItem);
+        renderItemRef.current = renderItem;
+        const stableRenderItem = useCallback((p: any) => (renderItemRef.current as any)(p), []);
+
+        const keyExtractorRef = useRef(keyExtractor);
+        keyExtractorRef.current = keyExtractor;
+        const stableKeyExtractor = keyExtractor
+            ? useCallback((item: any, index: number) => keyExtractorRef.current!(item, index), [])
+            : undefined;
+
+        const onEndReachedRef = useRef(onEndReached);
+        onEndReachedRef.current = onEndReached;
+        const stableOnEndReached = onEndReached
+            ? useCallback((info: any) => onEndReachedRef.current?.(info), [])
+            : undefined;
+
+        const onStartReachedRef = useRef(onStartReached);
+        onStartReachedRef.current = onStartReached;
+        const stableOnStartReached = onStartReached
+            ? useCallback((info: any) => onStartReachedRef.current?.(info), [])
+            : undefined;
+
+        const onViewableItemsChangedRef = useRef(onViewableItemsChanged);
+        onViewableItemsChangedRef.current = onViewableItemsChanged;
+        const stableOnViewableItemsChanged = onViewableItemsChanged
+            ? useCallback((info: any) => onViewableItemsChangedRef.current?.(info), [])
+            : undefined;
+
+        // Structural/layout props that legitimately need to re-propagate when changed.
+        // Callbacks are excluded — they're stabilized via refs above.
+        // dataVersion is excluded — it's per-dataset via DatasetEntry.dataVersion.
         const sharedLayerProps = useMemo(
             () => ({
                 alignItemsAtEnd,
                 columnWrapperStyle,
                 contentContainerStyle,
-                dataVersion,
                 drawDistance,
                 enableAverages,
                 estimatedItemSize,
@@ -302,21 +333,21 @@ export const LegendListDatasets = typedMemo(
                 initialScrollIndex,
                 initialScrollOffset,
                 itemsAreEqual,
-                keyExtractor,
+                keyExtractor: stableKeyExtractor,
                 maintainScrollAtEnd,
                 maintainScrollAtEndThreshold,
                 maintainVisibleContentPosition,
                 numColumns,
-                onEndReached,
+                onEndReached: stableOnEndReached,
                 onEndReachedThreshold,
                 onItemSizeChanged,
                 onLoad,
-                onStartReached,
+                onStartReached: stableOnStartReached,
                 onStartReachedThreshold,
                 onStickyHeaderChange,
-                onViewableItemsChanged,
+                onViewableItemsChanged: stableOnViewableItemsChanged,
                 recycleItems,
-                renderItem,
+                renderItem: stableRenderItem,
                 snapToIndices,
                 stickyHeaderConfig,
                 stickyIndices,
@@ -329,7 +360,6 @@ export const LegendListDatasets = typedMemo(
                 alignItemsAtEnd,
                 columnWrapperStyle,
                 contentContainerStyle,
-                dataVersion,
                 drawDistance,
                 enableAverages,
                 estimatedItemSize,
@@ -339,27 +369,22 @@ export const LegendListDatasets = typedMemo(
                 getFixedItemSize,
                 getItemType,
                 horizontal,
+                ItemSeparatorComponent,
                 initialContainerPoolRatio,
                 initialHeaderSize,
                 initialScrollIndex,
                 initialScrollOffset,
-                ItemSeparatorComponent,
                 itemsAreEqual,
-                keyExtractor,
                 maintainScrollAtEnd,
                 maintainScrollAtEndThreshold,
                 maintainVisibleContentPosition,
                 numColumns,
-                onEndReached,
                 onEndReachedThreshold,
                 onItemSizeChanged,
                 onLoad,
-                onStartReached,
                 onStartReachedThreshold,
                 onStickyHeaderChange,
-                onViewableItemsChanged,
                 recycleItems,
-                renderItem,
                 snapToIndices,
                 stickyHeaderConfig,
                 stickyIndices,
@@ -413,6 +438,7 @@ export const LegendListDatasets = typedMemo(
                                 {...sharedLayerProps}
                                 active={dataset.active}
                                 data={dataset.data}
+                                dataVersion={dataset.dataVersion}
                                 ref={(handle: DatasetLayerHandle | null) => {
                                     layerRefs.current[index] = handle;
                                 }}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 export { LegendList } from "@/components/LegendList";
+export { LegendListDatasets } from "@/components/LegendListDatasets";
 export {
     useIsLastItem,
     useListScrollSize,
@@ -8,4 +9,5 @@ export {
     useViewability,
     useViewabilityAmount,
 } from "@/state/ContextContainer";
+export type { DatasetEntry, LegendListDatasetsProps } from "@/types";
 export type * from "./types";

--- a/src/integrations/keyboard.tsx
+++ b/src/integrations/keyboard.tsx
@@ -222,7 +222,7 @@ export const KeyboardAvoidingLegendList = (forwardRef as TypedForwardRef)(functi
               }),
               [styleProp, keyboardInset],
           )
-        : undefined;
+        : styleProp;
 
     return (
         <AnimatedLegendList

--- a/src/integrations/reanimated.tsx
+++ b/src/integrations/reanimated.tsx
@@ -66,13 +66,21 @@ const AnimatedLegendList = typedMemo(
         props: AnimatedLegendListProps<ItemT>,
         ref: React.Ref<LegendListRef>,
     ) {
-        const { refScrollView, ...rest } = props as AnimatedLegendListPropsBase<ItemT>;
+        const { refScrollView, ...rest } = props as AnimatedLegendListProps<ItemT>;
+        const { animatedProps } = props;
 
         const refLegendList = React.useRef<LegendListRef | null>(null);
 
         const combinedRef = useCombinedRef(refLegendList, ref);
 
-        return <AnimatedLegendListComponent ref={refScrollView} refLegendList={combinedRef} {...(rest as any)} />;
+        return (
+            <AnimatedLegendListComponent
+                animatedPropsInternal={animatedProps}
+                ref={refScrollView}
+                refLegendList={combinedRef}
+                {...(rest as any)}
+            />
+        );
     }),
 ) as AnimatedLegendListDefinition;
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -368,6 +368,22 @@ export interface ColumnWrapperStyle {
 
 export type LegendListProps<ItemT = any> = LegendListPropsBase<ItemT, ComponentProps<typeof ScrollView>>;
 
+export interface DatasetEntry<ItemT> {
+    /** Unique key for this dataset — used as a React key and for identity */
+    key: string;
+    /** Data array for this dataset */
+    data: ReadonlyArray<ItemT>;
+    /** Whether this dataset is the currently visible one */
+    active: boolean;
+}
+
+export type LegendListDatasetsProps<ItemT = any> = Omit<LegendListProps<ItemT>, "data" | "children" | "renderItem"> & {
+    datasets: DatasetEntry<ItemT>[];
+    renderItem:
+        | ((props: LegendListRenderItemProps<ItemT, string | undefined>) => ReactNode)
+        | React.ComponentType<LegendListRenderItemProps<ItemT, string | undefined>>;
+};
+
 export interface InternalState {
     positions: Map<string, number>;
     columns: Map<string, number>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -409,7 +409,7 @@ export interface DatasetEntry<ItemT> {
     getItemType?: (item: ItemT, index: number) => string | undefined;
 }
 
-export type LegendListDatasetsProps<ItemT = any> = Omit<LegendListProps<ItemT>, "data" | "children" | "renderItem"> & {
+export type LegendListDatasetsProps<ItemT = any> = Omit<LegendListProps<ItemT>, "data" | "children" | "dataVersion" | "renderItem"> & {
     datasets: DatasetEntry<ItemT>[];
     renderItem:
         | ((props: LegendListRenderItemProps<ItemT, string | undefined>) => ReactNode)

--- a/src/types.ts
+++ b/src/types.ts
@@ -381,6 +381,32 @@ export interface DatasetEntry<ItemT> {
      * would trigger a full rebuild on ALL datasets simultaneously.
      */
     dataVersion?: Key;
+    /**
+     * Per-dataset key extractor. Use this when different datasets have items
+     * of different shapes (e.g. spot items use item.spotId, futures use item.futuresId).
+     * Falls back to the shared keyExtractor prop if not provided.
+     */
+    keyExtractor?: (item: ItemT, index: number) => string;
+    /**
+     * Per-dataset estimated item size in pixels.
+     * Falls back to the shared estimatedItemSize prop if not provided.
+     */
+    estimatedItemSize?: number;
+    /**
+     * Per-dataset function to get estimated item size.
+     * Falls back to the shared getEstimatedItemSize prop if not provided.
+     */
+    getEstimatedItemSize?: (index: number, item: ItemT, type: string | undefined) => number;
+    /**
+     * Per-dataset function to get fixed item size.
+     * Falls back to the shared getFixedItemSize prop if not provided.
+     */
+    getFixedItemSize?: (index: number, item: ItemT, type: string | undefined) => number | undefined;
+    /**
+     * Per-dataset function to get item type for container recycling.
+     * Falls back to the shared getItemType prop if not provided.
+     */
+    getItemType?: (item: ItemT, index: number) => string | undefined;
 }
 
 export type LegendListDatasetsProps<ItemT = any> = Omit<LegendListProps<ItemT>, "data" | "children" | "renderItem"> & {

--- a/src/types.ts
+++ b/src/types.ts
@@ -375,6 +375,12 @@ export interface DatasetEntry<ItemT> {
     data: ReadonlyArray<ItemT>;
     /** Whether this dataset is the currently visible one */
     active: boolean;
+    /**
+     * Per-dataset version token. Increment this when mutating the data array
+     * in place for this specific dataset. Using the shared `dataVersion` prop
+     * would trigger a full rebuild on ALL datasets simultaneously.
+     */
+    dataVersion?: Key;
 }
 
 export type LegendListDatasetsProps<ItemT = any> = Omit<LegendListProps<ItemT>, "data" | "children" | "renderItem"> & {


### PR DESCRIPTION
## Summary

- Adds `LegendListDatasets` component for rendering multiple independent lists under a single shared ScrollView, header, and footer
- Each dataset gets its own full LegendList engine (container pool, position map, size cache) wrapped in `React.Activity` for effect freezing
- Optimizes tab switching: inactive layers use `opacity: 0` + `pointerEvents: none` instead of `height: 0` to keep native layout warm
- Skips `calculateItemsInView` recalculation on reactivation when scroll position is still within the cached visible range
- Adds `ActivityOrFragment` fallback for React 18 compatibility
- Per-dataset overrides for `keyExtractor`, `estimatedItemSize`, `getEstimatedItemSize`, `getFixedItemSize`, and `getItemType`
- Full `LegendListRef` imperative API delegates to the active dataset

## New files

- `src/components/LegendListDatasets.tsx` — parent component owning the shared ScrollView
- `src/components/DatasetLayer.tsx` — per-dataset list engine (headless LegendList)
- `DATASETS.md` — full documentation (architecture, usage, performance tips, footguns)
- `example/app/datasets/index.tsx` — example app with 5 continent-based tabs

## Test plan

- [ ] Run example app, navigate to "Datasets (tabbed lists)"
- [ ] Switch between continent tabs — verify instant switching with no flicker
- [ ] Scroll down on one tab, switch to another, switch back — verify scroll position and items are preserved
- [ ] Verify shared header (title + tab bar) scrolls with content
- [ ] Verify inactive tabs don't receive scroll events or trigger recalculations
- [ ] Test with `recycleItems={true}` and `recycleItems={false}`