### PR TITLE
fix(reanimated): drop unused animatedPropsInternal that leaks animated value to inner LegendList

### DIFF
--- a/src/integrations/reanimated.tsx
+++ b/src/integrations/reanimated.tsx
@@ -67,19 +67,13 @@ const AnimatedLegendList = typedMemo(
         ref: React.Ref<LegendListRef>,
     ) {
         const { refScrollView, ...rest } = props as AnimatedLegendListProps<ItemT>;
-        const { animatedProps } = props;
 
         const refLegendList = React.useRef<LegendListRef | null>(null);
 
         const combinedRef = useCombinedRef(refLegendList, ref);
 
         return (
-            <AnimatedLegendListComponent
-                animatedPropsInternal={animatedProps}
-                ref={refScrollView}
-                refLegendList={combinedRef}
-                {...(rest as any)}
-            />
+            <AnimatedLegendListComponent ref={refScrollView} refLegendList={combinedRef} {...(rest as any)} />
         );
     }),
 ) as AnimatedLegendListDefinition;


### PR DESCRIPTION
## Summary

`AnimatedLegendList` (in `src/integrations/reanimated.tsx`) passes
`animatedPropsInternal={animatedProps}` to `AnimatedLegendListComponent`,
but no component in this repo reads `animatedPropsInternal` — neither
`LegendListForwardedRef` nor the underlying `LegendList`. The prop was
introduced in #375's backport (commit 03e1574) without a consumer.

Because `Reanimated.createAnimatedComponent` only filters the
`animatedProps` key (see [`PropsFilter.tsx`](https://github.com/software-mansion/react-native-reanimated/blob/main/packages/react-native-reanimated/src/createAnimatedComponent/PropsFilter.tsx)),
`animatedPropsInternal` is forwarded as a regular prop to the
non-animated inner `LegendList`. Its value is still the object returned
by `useAnimatedProps` (containing `viewDescriptors`, `initial`, etc.),
which trips Reanimated's runtime check and emits the warning:

> Trying to access a shared value's value inside the inline style.
> Perhaps you are trying to pass an animated style to a non-animated
> component.

This fires every time `KeyboardAvoidingLegendList` renders, since it
builds an `animatedProps` via `useAnimatedProps` for the iOS
`contentInset` animation.

## Fix

Remove the dead `animatedPropsInternal` alias. `animatedProps` already
flows through `...rest`, where `createAnimatedComponent` extracts and
applies it correctly. This restores the pre-#375 wiring while keeping
the rest of that PR intact.

```diff
 const { refScrollView, ...rest } = props as AnimatedLegendListProps<ItemT>;
-const { animatedProps } = props;

 const refLegendList = React.useRef<LegendListRef | null>(null);
 const combinedRef = useCombinedRef(refLegendList, ref);

 return (
-    <AnimatedLegendListComponent
-        animatedPropsInternal={animatedProps}
-        ref={refScrollView}
-        refLegendList={combinedRef}
-        {...(rest as any)}
-    />
+    <AnimatedLegendListComponent ref={refScrollView} refLegendList={combinedRef} {...(rest as any)} />
 );
```

## Test plan

- [x] `KeyboardAvoidingLegendList` no longer emits the Reanimated
      "shared value inside inline style" warning when the keyboard
      opens / closes.
- [x] iOS `contentInset.bottom` still animates with the keyboard.
- [x] Android `marginBottom` keyboard inset still animates.
- [x] `bunx biome check src/integrations/reanimated.tsx` passes.