### PR TITLE
fix(reanimated): drop unused `animatedPropsInternal` that throws Reanimated error on render

### DIFF
--- a/src/integrations/reanimated.tsx
+++ b/src/integrations/reanimated.tsx
@@ -67,19 +67,13 @@ const AnimatedLegendList = typedMemo(
         ref: React.Ref<LegendListRef>,
     ) {
         const { refScrollView, ...rest } = props as AnimatedLegendListProps<ItemT>;
-        const { animatedProps } = props;
 
         const refLegendList = React.useRef<LegendListRef | null>(null);
 
         const combinedRef = useCombinedRef(refLegendList, ref);
 
         return (
-            <AnimatedLegendListComponent
-                animatedPropsInternal={animatedProps}
-                ref={refScrollView}
-                refLegendList={combinedRef}
-                {...(rest as any)}
-            />
+            <AnimatedLegendListComponent ref={refScrollView} refLegendList={combinedRef} {...(rest as any)} />
         );
     }),
 ) as AnimatedLegendListDefinition;


### PR DESCRIPTION
Closes #437 

# Summary

Rendering `AnimatedLegendList` (or anything that wraps it, e.g. `KeyboardAvoidingLegendList` from `@legendapp/list/keyboard`) throws the following Reanimated error on mount under `react-native-reanimated@4`:

> [Reanimated] Perhaps you are trying to pass an animated style to a non-animated component. Try creating an animated component using `createAnimatedComponent` function or use `Animated.*` components.

No interaction is needed, the error fires the moment the list renders.

## Root cause

In Reanimated 4, the handle returned by `useAnimatedProps` / `useAnimatedStyle` has a `_requiresAnimatedComponent` getter (in `__DEV__`) that throws this exact message when read ([`useAnimatedStyle.ts#L611-L621`](https://github.com/software-mansion/react-native-reanimated/blob/main/packages/react-native-reanimated/src/hook/useAnimatedStyle.ts#L611-L621)):

```ts
get _requiresAnimatedComponent() {
    throw new ReanimatedError(
        'Perhaps you are trying to pass an animated style to a non-animated component. ...'
    );
},
```

`createAnimatedComponent` knows to skip these handles via `'_requiresAnimatedComponent' in style` (presence check, doesn't trigger the getter). Anything *outside* `createAnimatedComponent` that touches that property triggers it.

`AnimatedLegendList` in [`src/integrations/reanimated.tsx`](https://github.com/LegendApp/legend-list/blob/main/src/integrations/reanimated.tsx) (introduced by the backport in 03e1574 / #375) does:

```tsx
const { refScrollView, ...rest } = props;
const { animatedProps } = props;

return (
    <AnimatedLegendListComponent
        animatedPropsInternal={animatedProps}   // leak
        ref={refScrollView}
        refLegendList={combinedRef}
        {...(rest as any)}
    />
);
```

- `animatedPropsInternal` is **never read** anywhere in the package
- `Reanimated.createAnimatedComponent`'s [`PropsFilter`](https://github.com/software-mansion/react-native-reanimated/blob/main/packages/react-native-reanimated/src/createAnimatedComponent/PropsFilter.tsx) only filters the `animatedProps` key, so `animatedPropsInternal` is forwarded as a regular prop down to `LegendListForwardedRef` and into the non-animated inner `<LegendList>`, carrying the live `useAnimatedProps` handle.
- During render, the handle's `_requiresAnimatedComponent` getter is touched and Reanimated 4 throws.

In Reanimated 3 the same leak existed but only emitted a soft warning, which is presumably why this slipped through. Reanimated 4 promoted it to a thrown error, so every app on Reanimated 4 sees a redbox the moment `KeyboardAvoidingLegendList` (or any direct `AnimatedLegendList` consumer) renders.

## Fix

Drop the dead `animatedPropsInternal` alias. `animatedProps` already flows through `...rest`. `createAnimatedComponent` extracts and applies it correctly, and nothing animated leaks to the inner non-animated child. This restores the pre-#375 wiring while keeping the rest of that PR intact.

```diff
 const { refScrollView, ...rest } = props as AnimatedLegendListProps<ItemT>;
-const { animatedProps } = props;

 const refLegendList = React.useRef<LegendListRef | null>(null);
 const combinedRef = useCombinedRef(refLegendList, ref);

 return (
-    <AnimatedLegendListComponent
-        animatedPropsInternal={animatedProps}
-        ref={refScrollView}
-        refLegendList={combinedRef}
-        {...(rest as any)}
-    />
+    <AnimatedLegendListComponent ref={refScrollView} refLegendList={combinedRef} {...(rest as any)} />
 );
```

## Repro

```tsx
import { KeyboardAvoidingLegendList } from "@legendapp/list/keyboard";

const items = [{ id: "a", text: "A" }, { id: "b", text: "B" }];

export function Repro() {
    return (
        <KeyboardAvoidingLegendList
            data={items}
            renderItem={({ item }) => <Text>{item.text}</Text>}
            keyExtractor={(item) => item.id}
        />
    );
}
```

## Test plan

- [x] Redbox no longer appears when `AnimatedLegendList` / `KeyboardAvoidingLegendList` mounts under Reanimated 4.
- [x] `bunx biome check src/integrations/reanimated.tsx` passes.

## Environment

- `@legendapp/list`: 2.0.19
- `react-native-reanimated`: 4.2.1
- `react-native`: 0.83.2
- Expo SDK 55 (iOS + Android)