### PR TITLE
fix: call function renderItem directly to prevent remount on data updates

### DIFF
--- a/__tests__/components/LegendList.dataRefresh.integration.test.tsx
+++ b/__tests__/components/LegendList.dataRefresh.integration.test.tsx
@@ -201,6 +201,63 @@ describe("LegendList data refresh integration", () => {
         await cleanupRenderer(renderer);
     });
 
+    it("does not remount item subtrees when renderItem callback identity changes", async () => {
+        const events: string[] = [];
+        const data = [{ id: "item-1", label: "Alpha" }];
+        const Row = ({ item }: { item: { id: string; label: string } }) => {
+            React.useEffect(() => {
+                events.push(`mount:${item.id}`);
+                return () => {
+                    events.push(`unmount:${item.id}`);
+                };
+            }, [item.id]);
+
+            return <Text>{item.label}</Text>;
+        };
+
+        const { LegendList } = await import("../../src/components/LegendList?renderitem-remount-regression");
+        const renderer = await createRenderer(
+            <LegendList
+                data={data}
+                drawDistance={0}
+                estimatedItemSize={100}
+                getFixedItemSize={() => 100}
+                keyExtractor={(item: { id: string }) => item.id}
+                recycleItems={false}
+                renderItem={({ item }: { item: { id: string; label: string } }) => <Row item={item} />}
+            />,
+        );
+
+        await flushFrames();
+        await act(async () => {
+            lastListProps?.onLayout?.(layoutEvent as any);
+        });
+        await flushFrames(8);
+
+        expect(getRenderedLabels(renderer)).toContain("Alpha");
+        expect(events).toEqual(["mount:item-1"]);
+
+        await act(async () => {
+            renderer.update(
+                <LegendList
+                    data={[{ id: "item-1", label: "Beta" }]}
+                    drawDistance={0}
+                    estimatedItemSize={100}
+                    getFixedItemSize={() => 100}
+                    keyExtractor={(item: { id: string }) => item.id}
+                    recycleItems={false}
+                    renderItem={({ item }: { item: { id: string; label: string } }) => <Row item={item} />}
+                />,
+            );
+        });
+        await flushFrames(8);
+
+        expect(getRenderedLabels(renderer)).toContain("Beta");
+        expect(events).toEqual(["mount:item-1"]);
+
+        await cleanupRenderer(renderer);
+    });
+
     it("keeps semantically equal same-key replacements on the cheap path when itemsAreEqual returns true", async () => {
         const data = [{ id: "item-1", label: "Alpha", version: 1 }];
 

--- a/__tests__/utils/getRenderedItem.test.ts
+++ b/__tests__/utils/getRenderedItem.test.ts
@@ -1,6 +1,6 @@
 import React from "react";
 
-import { beforeEach, describe, expect, it } from "bun:test";
+import { beforeEach, describe, expect, it, mock } from "bun:test";
 import "../setup"; // Import global test setup
 import { Text } from "react-native";
 
@@ -60,9 +60,19 @@ describe("getRenderedItem", () => {
         });
 
         it("should pass correct props to renderItem", () => {
+            const renderItem = mock((props: any) => React.createElement("div", null, props.item.name));
+            mockState.props.renderItem = renderItem;
+
             const result = getRenderedItem(mockCtx, "item_0");
 
             expect(result).not.toBeNull();
+            expect(renderItem).toHaveBeenCalledWith({
+                data: mockState.props.data,
+                extraData: null,
+                index: 0,
+                item: { id: "item1", name: "First" },
+                type: "",
+            });
             expect(React.isValidElement(result!.renderedItem)).toBe(true);
             const element = result!.renderedItem as React.ReactElement;
             expect(element.type).toBe("div");
@@ -70,13 +80,21 @@ describe("getRenderedItem", () => {
 
         it("should include extraData from context", () => {
             const extraData = { theme: "dark", version: "1.0" };
+            const renderItem = mock((props: any) => React.createElement("div", null, props.extraData.theme));
+            mockState.props.renderItem = renderItem;
             mockCtx.values.set("extraData", extraData);
 
             const result = getRenderedItem(mockCtx, "item_1");
 
             expect(result).not.toBeNull();
+            expect(renderItem).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    extraData,
+                    item: { id: "item2", name: "Second" },
+                }),
+            );
             const element = result!.renderedItem as React.ReactElement;
-            expect(element.props.children).toContain("Second");
+            expect(element.props.children).toBe("dark");
         });
 
         it("should handle different item types", () => {
@@ -211,32 +229,62 @@ describe("getRenderedItem", () => {
         });
 
         it("should handle complex renderItem with multiple props", () => {
-            const ComplexRenderItem = ({ item, index, extraData }: any) =>
+            const complexRenderItem = mock(({ item, index, extraData, type }: any) =>
                 React.createElement(
                     "div",
                     {
                         "data-id": item.id,
                         "data-index": index,
                         "data-theme": extraData?.theme,
+                        "data-type": type,
                     },
                     item.name,
-                );
+                ),
+            );
 
-            mockState.props.renderItem = ComplexRenderItem;
+            mockState.props.getItemType = () => "message";
+            mockState.props.renderItem = complexRenderItem;
             mockCtx.values.set("extraData", { theme: "dark" });
 
             const result = getRenderedItem(mockCtx, "item_1");
 
             expect(result).not.toBeNull();
+            expect(complexRenderItem).toHaveBeenCalledWith({
+                data: mockState.props.data,
+                extraData: { theme: "dark" },
+                index: 1,
+                item: { id: "item2", name: "Second" },
+                type: "message",
+            });
             expect(React.isValidElement(result!.renderedItem)).toBe(true);
             const element = result!.renderedItem as React.ReactElement;
             expect(element.type).toBe("div");
             expect(element.props["data-theme"]).toBe("dark");
+            expect(element.props["data-type"]).toBe("message");
         });
 
-        // Note: function components that use Hooks must be rendered through
-        // React.createElement (i.e. passed as a stable component reference).
-        // Plain function callbacks are called directly for performance.
+        it("should support hook components returned from the render callback", () => {
+            const HookItem = ({ item }: any) => {
+                const [label] = React.useState(item.name);
+                return React.createElement(Text, null, label);
+            };
+            const MemoContainer = () => {
+                const renderedItem = React.useMemo(() => getRenderedItem(mockCtx, "item_0")?.renderedItem ?? null, []);
+                return React.createElement(React.Fragment, null, renderedItem);
+            };
+
+            mockState.props.renderItem = ({ item }: any) => React.createElement(HookItem, { item });
+
+            const result = getRenderedItem(mockCtx, "item_0");
+
+            expect(result).not.toBeNull();
+            expect(React.isValidElement(result!.renderedItem)).toBe(true);
+            expect((result!.renderedItem as React.ReactElement).type).toBe(HookItem);
+            expect(() => {
+                const rendered = render(React.createElement(MemoContainer));
+                rendered.unmount();
+            }).not.toThrow();
+        });
     });
 
     describe("context interaction", () => {

--- a/__tests__/utils/getRenderedItem.test.ts
+++ b/__tests__/utils/getRenderedItem.test.ts
@@ -65,12 +65,7 @@ describe("getRenderedItem", () => {
             expect(result).not.toBeNull();
             expect(React.isValidElement(result!.renderedItem)).toBe(true);
             const element = result!.renderedItem as React.ReactElement;
-            expect(element.type).toBe(MockRenderItem);
-            expect(element.props.item).toEqual({ id: "item1", name: "First" });
-            expect(element.props.index).toBe(0);
-            expect(element.props.data).toEqual(mockState.props.data);
-            expect(element.props.extraData).toBeNull();
-            expect(element.props.type).toBe("");
+            expect(element.type).toBe("div");
         });
 
         it("should include extraData from context", () => {
@@ -81,7 +76,7 @@ describe("getRenderedItem", () => {
 
             expect(result).not.toBeNull();
             const element = result!.renderedItem as React.ReactElement;
-            expect(element.props.extraData).toBe(extraData);
+            expect(element.props.children).toContain("Second");
         });
 
         it("should handle different item types", () => {
@@ -185,11 +180,7 @@ describe("getRenderedItem", () => {
         it("should handle renderItem throwing an error", () => {
             mockState.props.renderItem = ThrowingRenderItem;
 
-            expect(() => getRenderedItem(mockCtx, "item_0")).not.toThrow();
-
-            const result = getRenderedItem(mockCtx, "item_0");
-            expect(result).not.toBeNull();
-            expect(() => render(result!.renderedItem as React.ReactElement)).toThrow("Render error");
+            expect(() => getRenderedItem(mockCtx, "item_0")).toThrow("Render error");
         });
 
         it("should handle renderItem returning null", () => {
@@ -198,7 +189,7 @@ describe("getRenderedItem", () => {
             const result = getRenderedItem(mockCtx, "item_0");
 
             expect(result).not.toBeNull();
-            expect(React.isValidElement(result!.renderedItem)).toBe(true);
+            expect(result!.renderedItem).toBeNull();
         });
 
         it("should handle renderItem returning undefined", () => {
@@ -207,7 +198,7 @@ describe("getRenderedItem", () => {
             const result = getRenderedItem(mockCtx, "item_0");
 
             expect(result).not.toBeNull();
-            expect(React.isValidElement(result!.renderedItem)).toBe(true);
+            expect(result!.renderedItem).toBeUndefined();
         });
 
         it("should handle renderItem returning non-React element", () => {
@@ -216,7 +207,7 @@ describe("getRenderedItem", () => {
             const result = getRenderedItem(mockCtx, "item_0");
 
             expect(result).not.toBeNull();
-            expect(React.isValidElement(result!.renderedItem)).toBe(true);
+            expect(result!.renderedItem).toBe("plain string");
         });
 
         it("should handle complex renderItem with multiple props", () => {
@@ -239,32 +230,13 @@ describe("getRenderedItem", () => {
             expect(result).not.toBeNull();
             expect(React.isValidElement(result!.renderedItem)).toBe(true);
             const element = result!.renderedItem as React.ReactElement;
-            expect(element.type).toBe(ComplexRenderItem);
-            expect(element.props.extraData).toEqual({ theme: "dark" });
+            expect(element.type).toBe("div");
+            expect(element.props["data-theme"]).toBe("dark");
         });
 
-        it("should support function components that use Hooks", () => {
-            const HookRenderItem = ({ item }: any) => {
-                const [label] = React.useState(item.name);
-                return React.createElement(Text, null, label);
-            };
-            const MemoContainer = () => {
-                const renderedItem = React.useMemo(() => getRenderedItem(mockCtx, "item_0")?.renderedItem ?? null, []);
-                return React.createElement(React.Fragment, null, renderedItem);
-            };
-
-            mockState.props.renderItem = HookRenderItem;
-
-            const result = getRenderedItem(mockCtx, "item_0");
-
-            expect(result).not.toBeNull();
-            expect(React.isValidElement(result!.renderedItem)).toBe(true);
-            expect((result!.renderedItem as React.ReactElement).type).toBe(HookRenderItem);
-            expect(() => {
-                const rendered = render(React.createElement(MemoContainer));
-                rendered.unmount();
-            }).not.toThrow();
-        });
+        // Note: function components that use Hooks must be rendered through
+        // React.createElement (i.e. passed as a stable component reference).
+        // Plain function callbacks are called directly for performance.
     });
 
     describe("context interaction", () => {
@@ -274,8 +246,7 @@ describe("getRenderedItem", () => {
             const result = getRenderedItem(mockCtx, "item_0");
 
             expect(result).not.toBeNull();
-            const element = result!.renderedItem as React.ReactElement;
-            expect(element.props.extraData).toBeUndefined();
+            expect(React.isValidElement(result!.renderedItem)).toBe(true);
         });
 
         it("should handle different extraData types", () => {
@@ -287,8 +258,7 @@ describe("getRenderedItem", () => {
                 const result = getRenderedItem(mockCtx, "item_0");
 
                 expect(result).not.toBeNull();
-                const element = result!.renderedItem as React.ReactElement;
-                expect(element.props.extraData).toBe(extraData);
+                expect(React.isValidElement(result!.renderedItem)).toBe(true);
             });
         });
     });
@@ -353,7 +323,9 @@ describe("getRenderedItem", () => {
             expect(result!.item).toBe(0);
             expect(result!.renderedItem).not.toBeNull();
             expect(React.isValidElement(result!.renderedItem)).toBe(true);
-            expect((result!.renderedItem as React.ReactElement).props.item).toBe(0);
+            const element = result!.renderedItem as React.ReactElement;
+            expect(element.type).toBe("div");
+            expect(element.props.children).toBe("Value: 0");
         });
     });
 

--- a/src/components/LegendList.tsx
+++ b/src/components/LegendList.tsx
@@ -101,9 +101,7 @@ export const LegendList = typedMemo(
 type LegendListInnerProps<T> = Omit<LegendListPropsBase<T, LooseScrollViewProps>, "children"> & {
     childrenMode?: boolean;
     data: ReadonlyArray<T>;
-    renderItem:
-        | ((props: LegendListRenderItemProps<T, string | undefined>) => React.ReactNode)
-        | React.ComponentType<LegendListRenderItemProps<T, string | undefined>>;
+    renderItem: (props: LegendListRenderItemProps<T, string | undefined>) => React.ReactNode;
 };
 
 // biome-ignore lint/nursery/noShadow: const function name shadowing is intentional

--- a/src/types.base.ts
+++ b/src/types.base.ts
@@ -52,15 +52,11 @@ interface DataModeProps<ItemT, TItemType extends string | undefined> {
     data: ReadonlyArray<ItemT>;
 
     /**
-     * Function or React component to render each item in the list.
-     * Can be either:
-     * - A function: (props: LegendListRenderItemProps<ItemT>) => ReactNode
-     * - A React component: React.ComponentType<LegendListRenderItemProps<ItemT>>
+     * Callback to render each item in the list.
+     * To use hooks in an item component, return that component from this callback.
      * @required when using data mode
      */
-    renderItem:
-        | ((props: LegendListRenderItemProps<ItemT, TItemType>) => React.ReactNode)
-        | React.ComponentType<LegendListRenderItemProps<ItemT, TItemType>>;
+    renderItem: (props: LegendListRenderItemProps<ItemT, TItemType>) => React.ReactNode;
 
     children?: never;
 }

--- a/src/types.internal.ts
+++ b/src/types.internal.ts
@@ -118,9 +118,7 @@ type InternalInitialScrollSession = OffsetInitialScrollSession | BootstrapOwnedI
 
 type LegendListPropsInternal = LegendListPropsBase<any, Record<string, any>, string | undefined> & {
     data: readonly any[];
-    renderItem:
-        | ((props: LegendListRenderItemProps<any, string | undefined>) => React.ReactNode)
-        | React.ComponentType<LegendListRenderItemProps<any, string | undefined>>;
+    renderItem: (props: LegendListRenderItemProps<any, string | undefined>) => React.ReactNode;
 };
 
 export interface PendingDataComparison {

--- a/src/utils/getRenderedItem.ts
+++ b/src/utils/getRenderedItem.ts
@@ -1,7 +1,7 @@
-import React from "react";
+import type React from "react";
 
 import { peek$, type StateContext } from "@/state/state";
-import { isFunction, isNullOrUndefined } from "@/utils/helpers";
+import { isNullOrUndefined } from "@/utils/helpers";
 
 export function getRenderedItem(ctx: StateContext, key: string) {
     const state = ctx.state;
@@ -34,9 +34,7 @@ export function getRenderedItem(ctx: StateContext, key: string) {
             type: getItemType ? (getItemType(item, index) ?? "") : "",
         };
 
-        renderedItem = (
-            isFunction(renderItem) ? renderItem(itemProps) : React.createElement(renderItem, itemProps)
-        ) as React.ReactNode;
+        renderedItem = renderItem(itemProps) as React.ReactNode;
     }
 
     return { index, item: data[index], renderedItem };

--- a/src/utils/getRenderedItem.ts
+++ b/src/utils/getRenderedItem.ts
@@ -1,7 +1,7 @@
 import React from "react";
 
 import { peek$, type StateContext } from "@/state/state";
-import { isNullOrUndefined } from "@/utils/helpers";
+import { isFunction, isNullOrUndefined } from "@/utils/helpers";
 
 export function getRenderedItem(ctx: StateContext, key: string) {
     const state = ctx.state;
@@ -34,8 +34,9 @@ export function getRenderedItem(ctx: StateContext, key: string) {
             type: getItemType ? (getItemType(item, index) ?? "") : "",
         };
 
-        // Always render through React so function components can safely use Hooks.
-        renderedItem = React.createElement(renderItem, itemProps) as React.ReactNode;
+        renderedItem = (
+            isFunction(renderItem) ? renderItem(itemProps) : React.createElement(renderItem, itemProps)
+        ) as React.ReactNode;
     }
 
     return { index, item: data[index], renderedItem };


### PR DESCRIPTION
## Problem

Since 50ee631, `getRenderedItem` always uses `React.createElement(renderItem, itemProps)`. This treats the `renderItem` function reference as a React component type. When the reference changes between renders (e.g. inline callbacks, or callbacks with deps that change on data updates), React sees a different component type and **unmounts/remounts the entire cell subtree**.

In practice this causes all images and content in a list to flash on any state change, because every cell is fully destroyed and recreated.


https://github.com/user-attachments/assets/ffe53556-c1e3-43ba-b747-d63df9f6926c



## Fix

Restore the `isFunction` check that was removed in 50ee631. Plain functions are called directly as `renderItem(itemProps)`.

## Tradeoff

Function components passed directly as `renderItem` that use hooks internally will no longer work as they need to be wrapped in a callback, so this PR will likely need a few more changes before it's ready to merge.

Also I had to modify quite a few of the tests to get it to pass which I don't feel super confident about, ideally we'd want to try and support both uses cases while still fixing the rerender issue. 😅