### PR TITLE
feat: add LegendListDatasets

### DIFF
--- a/__tests__/components/LegendListGroup.test.tsx
+++ b/__tests__/components/LegendListGroup.test.tsx
@@ -1,0 +1,326 @@
+import * as React from "react";
+import { Text } from "react-native";
+
+import { beforeEach, describe, expect, it, mock } from "bun:test";
+import { useArr$, useStateContext } from "../../src/state/state";
+import TestRenderer, { act } from "../helpers/testRenderer";
+import { registerBaseModuleMocks } from "../setup";
+
+type Item = { id: string; label: string };
+
+type ScrollHarness = {
+    getScrollCalls: () => Array<{ animated?: boolean; x?: number; y?: number }>;
+    getScrollProps: () => any;
+    ScrollComponent: React.ComponentType<any>;
+};
+
+let listPropsByFirstId: Map<string, any>;
+let listScrollCallsByFirstId: Map<string, number>;
+
+function createScrollHarness(): ScrollHarness {
+    let scrollProps: any;
+    const scrollCalls: Array<{ animated?: boolean; x?: number; y?: number }> = [];
+
+    const ScrollComponent = React.forwardRef(function ScrollHarnessComponent(props: any, ref: React.Ref<any>) {
+        scrollProps = props;
+        React.useImperativeHandle(ref, () => ({
+            flashScrollIndicators: () => undefined,
+            getScrollableNode: () => null,
+            getScrollResponder: () => null,
+            scrollTo: (params: { animated?: boolean; x?: number; y?: number }) => {
+                scrollCalls.push(params);
+            },
+            scrollToEnd: () => undefined,
+        }));
+
+        return <>{props.children}</>;
+    });
+
+    return {
+        getScrollCalls: () => scrollCalls,
+        getScrollProps: () => scrollProps,
+        ScrollComponent,
+    };
+}
+
+function IntegrationListComponent(props: any) {
+    const ctx = useStateContext();
+    const data = ctx.state.props.data as Item[];
+    const firstId = data[0]?.id ?? "empty";
+    const [numContainersPooled = 0] = useArr$(["numContainersPooled"]);
+    listPropsByFirstId.set(firstId, { ...props, data });
+
+    const children = props.canRender
+        ? Array.from({ length: numContainersPooled }, (_, id) => <Text key={id}>{firstId}</Text>)
+        : null;
+
+    return props.renderScrollComponent({
+        children,
+        contentContainerStyle: props.contentContainerStyle,
+        horizontal: props.horizontal,
+        onLayout: props.onLayout,
+        onMomentumScrollEnd: props.onMomentumScrollEnd,
+        onScroll: (event: any) => {
+            listScrollCallsByFirstId.set(firstId, (listScrollCallsByFirstId.get(firstId) ?? 0) + 1);
+            props.onScroll?.(event);
+        },
+        ref: props.refScrollView,
+        snapToOffsets: props.snapToOffsets,
+        style: props.style,
+    });
+}
+
+function registerLegendListGroupMocks() {
+    mock.restore();
+    registerBaseModuleMocks();
+    mock.module("@/components/ListComponent", () => ({
+        ListComponent: IntegrationListComponent,
+    }));
+
+    mock.module("@/core/ScrollAdjustHandler", () => ({
+        ScrollAdjustHandler: class {
+            requestAdjust() {}
+            setMounted() {}
+            getAdjust() {
+                return 0;
+            }
+            commitPendingAdjust() {}
+        },
+    }));
+}
+
+async function createRenderer(element: React.ReactElement) {
+    let renderer: ReturnType<typeof TestRenderer.create>;
+    await act(async () => {
+        renderer = TestRenderer.create(element);
+    });
+    return renderer!;
+}
+
+async function flushAsync() {
+    await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+}
+
+beforeEach(() => {
+    listPropsByFirstId = new Map();
+    listScrollCallsByFirstId = new Map();
+    registerLegendListGroupMocks();
+});
+
+describe("LegendListGroup", () => {
+    it("routes shared scroll events to the active list when activeKey changes", async () => {
+        const { ScrollComponent, getScrollProps } = createScrollHarness();
+        const { LegendListGroup } = await import("../../src/components/LegendListGroup?group-active-switching");
+        const lists = [
+            { data: [{ id: "a1", label: "A" }], key: "a", renderItem: () => null },
+            { data: [{ id: "b1", label: "B" }], key: "b", renderItem: () => null },
+        ];
+        const renderer = await createRenderer(
+            <LegendListGroup
+                activeKey="a"
+                estimatedItemSize={20}
+                lists={lists}
+                recycleItems={false}
+                renderScrollComponent={(props) => <ScrollComponent {...props} />}
+            />,
+        );
+
+        await act(async () => {
+            getScrollProps().onScroll({ nativeEvent: { contentOffset: { x: 0, y: 10 } } });
+        });
+
+        expect(listScrollCallsByFirstId.get("a1")).toBe(1);
+        expect(listScrollCallsByFirstId.get("b1")).toBeUndefined();
+
+        await act(async () => {
+            renderer.update(
+                <LegendListGroup
+                    activeKey="b"
+                    estimatedItemSize={20}
+                    lists={lists}
+                    recycleItems={false}
+                    renderScrollComponent={(props) => <ScrollComponent {...props} />}
+                />,
+            );
+        });
+        await act(async () => {
+            getScrollProps().onScroll({ nativeEvent: { contentOffset: { x: 0, y: 20 } } });
+        });
+
+        expect(listScrollCallsByFirstId.get("b1")).toBe(1);
+
+        await act(async () => {
+            renderer.unmount();
+        });
+    });
+
+    it("keeps inactive list updates lazy until activation by default", async () => {
+        const { ScrollComponent } = createScrollHarness();
+        const { LegendListGroup } = await import("../../src/components/LegendListGroup?group-lazy-data");
+        const initialLists = [
+            { data: [{ id: "a1", label: "A" }], key: "a", renderItem: () => null },
+            { data: [{ id: "b1", label: "B" }], key: "b", renderItem: () => null },
+        ];
+        const nextLists = [initialLists[0], { data: [{ id: "b2", label: "B2" }], key: "b", renderItem: () => null }];
+        const renderer = await createRenderer(
+            <LegendListGroup
+                activeKey="a"
+                estimatedItemSize={20}
+                lists={initialLists}
+                recycleItems={false}
+                renderScrollComponent={(props) => <ScrollComponent {...props} />}
+            />,
+        );
+
+        await act(async () => {
+            renderer.update(
+                <LegendListGroup
+                    activeKey="a"
+                    estimatedItemSize={20}
+                    lists={nextLists}
+                    recycleItems={false}
+                    renderScrollComponent={(props) => <ScrollComponent {...props} />}
+                />,
+            );
+        });
+
+        expect(listPropsByFirstId.has("b2")).toBe(false);
+        expect(listPropsByFirstId.get("b1")?.data).toBe(initialLists[1].data);
+
+        await act(async () => {
+            renderer.update(
+                <LegendListGroup
+                    activeKey="b"
+                    estimatedItemSize={20}
+                    lists={nextLists}
+                    recycleItems={false}
+                    renderScrollComponent={(props) => <ScrollComponent {...props} />}
+                />,
+            );
+        });
+
+        expect(listPropsByFirstId.get("b2")?.data).toBe(nextLists[1].data);
+
+        await act(async () => {
+            renderer.unmount();
+        });
+    });
+
+    it("delegates imperative state to the active list", async () => {
+        const { ScrollComponent } = createScrollHarness();
+        const { LegendListGroup } = await import("../../src/components/LegendListGroup?group-ref-state");
+        const ref = React.createRef<any>();
+        const lists = [
+            { data: [{ id: "a1", label: "A" }], key: "a", renderItem: () => null },
+            { data: [{ id: "b1", label: "B" }], key: "b", renderItem: () => null },
+        ];
+        const renderer = await createRenderer(
+            <LegendListGroup
+                activeKey="b"
+                estimatedItemSize={20}
+                lists={lists}
+                recycleItems={false}
+                ref={ref}
+                renderScrollComponent={(props) => <ScrollComponent {...props} />}
+            />,
+        );
+
+        expect(ref.current.getState().data).toBe(lists[1].data);
+
+        await act(async () => {
+            renderer.update(
+                <LegendListGroup
+                    activeKey="a"
+                    estimatedItemSize={20}
+                    lists={lists}
+                    recycleItems={false}
+                    ref={ref}
+                    renderScrollComponent={(props) => <ScrollComponent {...props} />}
+                />,
+            );
+        });
+
+        expect(ref.current.getState().data).toBe(lists[0].data);
+
+        await act(async () => {
+            renderer.unmount();
+        });
+    });
+
+    it("uses maintainVisibleContentPosition from the active list", async () => {
+        const { ScrollComponent, getScrollProps } = createScrollHarness();
+        const { LegendListGroup } = await import("../../src/components/LegendListGroup?group-mvcp");
+        const lists = [
+            {
+                data: [{ id: "a1", label: "A" }],
+                key: "a",
+                maintainVisibleContentPosition: false,
+                renderItem: () => null,
+            },
+            {
+                data: [{ id: "b1", label: "B" }],
+                key: "b",
+                maintainVisibleContentPosition: true,
+                renderItem: () => null,
+            },
+        ];
+        const renderer = await createRenderer(
+            <LegendListGroup
+                activeKey="a"
+                estimatedItemSize={20}
+                lists={lists}
+                recycleItems={false}
+                renderScrollComponent={(props) => <ScrollComponent {...props} />}
+            />,
+        );
+
+        expect(getScrollProps().maintainVisibleContentPosition).toBeUndefined();
+
+        await act(async () => {
+            renderer.update(
+                <LegendListGroup
+                    activeKey="b"
+                    estimatedItemSize={20}
+                    lists={lists}
+                    recycleItems={false}
+                    renderScrollComponent={(props) => <ScrollComponent {...props} />}
+                />,
+            );
+        });
+
+        expect(getScrollProps().maintainVisibleContentPosition).toEqual({ minIndexForVisible: 0 });
+
+        await act(async () => {
+            renderer.unmount();
+        });
+    });
+
+    it("renders shared header and footer outside list layers", async () => {
+        const { ScrollComponent } = createScrollHarness();
+        const { LegendListGroup } = await import("../../src/components/LegendListGroup?group-header-footer");
+        const renderer = await createRenderer(
+            <LegendListGroup
+                activeKey="a"
+                estimatedItemSize={20}
+                ListFooterComponent={<Text>Shared footer</Text>}
+                ListHeaderComponent={<Text>Shared header</Text>}
+                lists={[{ data: [{ id: "a1", label: "A" }], key: "a", renderItem: () => null }]}
+                recycleItems={false}
+                renderScrollComponent={(props) => <ScrollComponent {...props} />}
+            />,
+        );
+
+        await flushAsync();
+
+        expect(listPropsByFirstId.get("a1")?.ListHeaderComponent).toBeUndefined();
+        expect(listPropsByFirstId.get("a1")?.ListFooterComponent).toBeUndefined();
+        expect(JSON.stringify(renderer.toJSON())).toContain("Shared header");
+        expect(JSON.stringify(renderer.toJSON())).toContain("Shared footer");
+
+        await act(async () => {
+            renderer.unmount();
+        });
+    });
+});

--- a/src/components/LegendListGroup.tsx
+++ b/src/components/LegendListGroup.tsx
@@ -1,0 +1,537 @@
+import * as React from "react";
+import { type ForwardedRef, useCallback, useImperativeHandle, useLayoutEffect, useMemo, useRef, useState } from "react";
+
+import { LegendList } from "@/components/LegendList";
+import { ListComponentScrollView } from "@/components/ListComponentScrollView";
+import { useCombinedRef } from "@/hooks/useCombinedRef";
+import { LayoutView } from "@/platform/LayoutView";
+import type { LayoutRectangle, NativeScrollEvent, NativeSyntheticEvent } from "@/platform/platform-types";
+import { RefreshControl } from "@/platform/RefreshControl";
+import { StyleSheet } from "@/platform/StyleSheet";
+import type { LooseScrollView, LooseScrollViewProps, ViewStyle } from "@/platform/scrollview-types";
+import { View } from "@/platform/ViewComponents";
+import { StateProvider, set$, useStateContext } from "@/state/state";
+import type {
+    LegendListGroupInactiveBehavior,
+    LegendListGroupInactiveUpdateMode,
+    LegendListGroupList,
+    LegendListGroupPropsBase,
+    LegendListRef,
+} from "@/types.base";
+import { typedForwardRef, typedMemo } from "@/types.internal";
+import { getComponent } from "@/utils/getComponent";
+import { normalizeMaintainVisibleContentPosition } from "@/utils/normalizeMaintainVisibleContentPosition";
+
+type LayerRegistration = {
+    onMomentumScrollEnd?: (event: NativeSyntheticEvent<NativeScrollEvent>) => void;
+    onScroll?: (event: NativeSyntheticEvent<NativeScrollEvent>) => void;
+    snapToOffsets?: number[];
+};
+
+type GroupContextValue = {
+    activeKey: string;
+    footerSize: number;
+    headerSize: number;
+    horizontal: boolean;
+    layout: LayoutRectangle | undefined;
+    registerLayer: (key: string, registration: LayerRegistration) => () => void;
+    sharedScrollerRef: React.RefObject<LooseScrollView | null>;
+};
+
+const GroupContext = React.createContext<GroupContextValue | null>(null);
+
+const Activity = (React as any).Activity as
+    | React.ComponentType<{ children: React.ReactNode; mode: "hidden" | "visible" }>
+    | undefined;
+
+function ActivityOrFragment({
+    children,
+    enabled,
+    mode,
+}: {
+    children: React.ReactNode;
+    enabled: boolean;
+    mode: "hidden" | "visible";
+}) {
+    if (enabled && Activity) {
+        return <Activity mode={mode}>{children}</Activity>;
+    }
+    return <>{children}</>;
+}
+
+function emptyLegendListState() {
+    return {
+        activeStickyIndex: -1,
+        contentLength: 0,
+        data: [],
+        elementAtIndex: () => undefined,
+        end: -1,
+        endBuffered: -1,
+        getAverageItemSizes: () => ({}),
+        isAtEnd: false,
+        isAtStart: true,
+        isEndReached: false,
+        isNearEnd: false,
+        isNearStart: true,
+        isStartReached: false,
+        isWithinMaintainScrollAtEndThreshold: false,
+        listen: () => () => {},
+        listenToPosition: () => () => {},
+        positionAtIndex: () => undefined as never,
+        positionByKey: () => undefined,
+        scroll: 0,
+        scrollLength: 0,
+        scrollVelocity: 0,
+        sizeAtIndex: () => undefined as never,
+        sizes: new Map(),
+        start: -1,
+        startBuffered: -1,
+    };
+}
+
+function getScrollOffset(event: NativeSyntheticEvent<NativeScrollEvent>, horizontal: boolean) {
+    return event.nativeEvent.contentOffset[horizontal ? "x" : "y"] ?? 0;
+}
+
+function isFiniteLayout(layout: LayoutRectangle | undefined) {
+    return !!layout && Number.isFinite(layout.width) && Number.isFinite(layout.height);
+}
+
+function GroupLayerScrollComponent({ listKey, scrollProps }: { listKey: string; scrollProps: LooseScrollViewProps }) {
+    const group = React.useContext(GroupContext);
+    const ctx = useStateContext();
+    const { children, onLayout, onMomentumScrollEnd, onScroll, ref, snapToOffsets } =
+        scrollProps as any as LooseScrollViewProps & {
+            children?: React.ReactNode;
+            ref?: React.Ref<LooseScrollView | null>;
+            snapToOffsets?: number[];
+        };
+
+    useImperativeHandle(ref, () => group?.sharedScrollerRef.current ?? null, [group]);
+
+    useLayoutEffect(() => {
+        if (!group) {
+            return;
+        }
+        return group.registerLayer(listKey, {
+            onMomentumScrollEnd: onMomentumScrollEnd as
+                | ((event: NativeSyntheticEvent<NativeScrollEvent>) => void)
+                | undefined,
+            onScroll: onScroll as ((event: NativeSyntheticEvent<NativeScrollEvent>) => void) | undefined,
+            snapToOffsets,
+        });
+    }, [group, listKey, onMomentumScrollEnd, onScroll, snapToOffsets]);
+
+    useLayoutEffect(() => {
+        if (!group) {
+            return;
+        }
+        set$(ctx, "headerSize", group.headerSize);
+    }, [ctx, group?.headerSize]);
+
+    useLayoutEffect(() => {
+        if (!group) {
+            return;
+        }
+        set$(ctx, "footerSize", group.footerSize);
+    }, [ctx, group?.footerSize]);
+
+    useLayoutEffect(() => {
+        if (!group || !isFiniteLayout(group.layout)) {
+            return;
+        }
+        onLayout?.({
+            nativeEvent: {
+                layout: group.layout!,
+            },
+        } as any);
+    }, [group?.layout, onLayout]);
+
+    return <View style={group?.horizontal ? { height: "100%" } : undefined}>{children}</View>;
+}
+
+type GroupLayerProps<ItemT> = {
+    inactiveBehavior: LegendListGroupInactiveBehavior;
+    inactiveUpdateMode: LegendListGroupInactiveUpdateMode;
+    isActive: boolean;
+    list: LegendListGroupList<ItemT>;
+    listRef: (ref: LegendListRef | null) => void;
+    sharedProps: Omit<
+        LegendListGroupPropsBase<ItemT, LooseScrollViewProps>,
+        "activeKey" | "inactiveBehavior" | "inactiveUpdateMode" | "lists" | "scrollPositionMode"
+    >;
+};
+
+function GroupLayer<ItemT>({
+    inactiveBehavior,
+    inactiveUpdateMode,
+    isActive,
+    list,
+    listRef,
+    sharedProps,
+}: GroupLayerProps<ItemT>) {
+    const [committedList, setCommittedList] = useState(list);
+    const shouldUseLatest = isActive || inactiveUpdateMode === "eager";
+    const effectiveList = shouldUseLatest ? list : committedList;
+
+    useLayoutEffect(() => {
+        if (shouldUseLatest) {
+            setCommittedList(list);
+        }
+    }, [list, shouldUseLatest]);
+
+    if (!isActive && inactiveBehavior === "unmount") {
+        return null;
+    }
+
+    const {
+        data,
+        key: _key,
+        ListFooterComponent: _ListFooterComponent,
+        ListFooterComponentStyle: _ListFooterComponentStyle,
+        ListHeaderComponent: _ListHeaderComponent,
+        ListHeaderComponentStyle: _ListHeaderComponentStyle,
+        numColumns: _numColumns,
+        renderItem,
+        ...listProps
+    } = effectiveList as LegendListGroupList<ItemT> & {
+        ListFooterComponent?: never;
+        ListFooterComponentStyle?: never;
+        ListHeaderComponent?: never;
+        ListHeaderComponentStyle?: never;
+        numColumns?: never;
+    };
+    const renderItemResolved = renderItem ?? sharedProps.renderItem;
+
+    if (!renderItemResolved) {
+        if (process.env.NODE_ENV !== "production") {
+            console.warn(`[legend-list] LegendListGroup list "${list.key}" has no renderItem.`);
+        }
+        return null;
+    }
+
+    return (
+        <View
+            style={
+                isActive
+                    ? undefined
+                    : ({
+                          left: 0,
+                          opacity: 0,
+                          pointerEvents: "none",
+                          position: "absolute",
+                          right: 0,
+                          top: 0,
+                      } as ViewStyle)
+            }
+        >
+            <ActivityOrFragment enabled={inactiveBehavior === "activity"} mode={isActive ? "visible" : "hidden"}>
+                <LegendList
+                    {...(sharedProps as any)}
+                    {...(listProps as any)}
+                    data={data}
+                    ListFooterComponent={undefined}
+                    ListHeaderComponent={undefined}
+                    onLayout={undefined}
+                    onRefresh={undefined}
+                    ref={listRef as any}
+                    refreshControl={undefined}
+                    refreshing={undefined}
+                    refScrollView={undefined}
+                    renderItem={renderItemResolved as any}
+                    renderScrollComponent={(scrollProps) => (
+                        <GroupLayerScrollComponent
+                            listKey={list.key}
+                            scrollProps={scrollProps as LooseScrollViewProps}
+                        />
+                    )}
+                />
+            </ActivityOrFragment>
+        </View>
+    );
+}
+
+const LegendListGroupInner = typedForwardRef(function LegendListGroupInnerComponent<ItemT>(
+    props: LegendListGroupPropsBase<ItemT, LooseScrollViewProps>,
+    forwardedRef: ForwardedRef<LegendListRef>,
+) {
+    const {
+        activeKey,
+        contentContainerStyle: contentContainerStyleProp,
+        horizontal = false,
+        inactiveBehavior = "hidden",
+        inactiveUpdateMode = "lazy",
+        lists,
+        ListFooterComponent,
+        ListFooterComponentStyle,
+        ListHeaderComponent,
+        ListHeaderComponentStyle,
+        onLayout: onLayoutProp,
+        onMomentumScrollEnd,
+        onRefresh,
+        onScroll: onScrollProp,
+        progressViewOffset,
+        refScrollView,
+        refreshing,
+        refreshControl,
+        renderScrollComponent,
+        scrollEventThrottle,
+        scrollPositionMode = "independent",
+        style: styleProp,
+        ...sharedProps
+    } = props;
+
+    const groupCtx = useStateContext();
+    const sharedScrollerRef = useRef<LooseScrollView | null>(null);
+    const combinedRef = useCombinedRef(sharedScrollerRef, refScrollView);
+    const listRefs = useRef(new Map<string, LegendListRef | null>());
+    const layerRegistrations = useRef(new Map<string, LayerRegistration>());
+    const renderScrollComponentRef = useRef(renderScrollComponent);
+    const savedOffsets = useRef(new Map<string, number>());
+    const activeKeyRef = useRef(activeKey);
+    const activeList = lists.find((list) => list.key === activeKey);
+    const [layout, setLayout] = useState<LayoutRectangle | undefined>();
+    const [headerSize, setHeaderSize] = useState(() => sharedProps.estimatedHeaderSize ?? 0);
+    const [footerSize, setFooterSize] = useState(0);
+    const [activeSnapToOffsets, setActiveSnapToOffsets] = useState<number[] | undefined>();
+
+    activeKeyRef.current = activeKey;
+    renderScrollComponentRef.current = renderScrollComponent;
+
+    if (!groupCtx.state) {
+        groupCtx.state = {
+            props: {
+                anchoredEndSpace: undefined,
+                contentInsetEndAdjustment: (sharedProps as any).contentInsetEndAdjustment,
+                horizontal: !!horizontal,
+            },
+            refScroller: sharedScrollerRef,
+        } as any;
+    }
+    groupCtx.state.props.horizontal = !!horizontal;
+    groupCtx.state.props.contentInsetEndAdjustment = (sharedProps as any).contentInsetEndAdjustment;
+    groupCtx.state.refScroller = sharedScrollerRef as any;
+
+    const setListRef = useCallback((key: string, ref: LegendListRef | null) => {
+        if (ref) {
+            listRefs.current.set(key, ref);
+        } else {
+            listRefs.current.delete(key);
+        }
+    }, []);
+
+    const registerLayer = useCallback((key: string, registration: LayerRegistration) => {
+        layerRegistrations.current.set(key, registration);
+        if (key === activeKeyRef.current) {
+            setActiveSnapToOffsets(registration.snapToOffsets);
+        }
+        return () => {
+            if (layerRegistrations.current.get(key) === registration) {
+                layerRegistrations.current.delete(key);
+                if (key === activeKeyRef.current) {
+                    setActiveSnapToOffsets(undefined);
+                }
+            }
+        };
+    }, []);
+
+    useLayoutEffect(() => {
+        setActiveSnapToOffsets(layerRegistrations.current.get(activeKey)?.snapToOffsets);
+        if (scrollPositionMode !== "independent") {
+            return;
+        }
+        const offset = savedOffsets.current.get(activeKey);
+        if (offset !== undefined) {
+            requestAnimationFrame(() => {
+                sharedScrollerRef.current?.scrollTo({
+                    animated: false,
+                    x: horizontal ? offset : 0,
+                    y: horizontal ? 0 : offset,
+                });
+            });
+        }
+    }, [activeKey, horizontal, scrollPositionMode]);
+
+    const activeMaintainVisibleContentPosition = normalizeMaintainVisibleContentPosition(
+        activeList?.maintainVisibleContentPosition ?? sharedProps.maintainVisibleContentPosition,
+    );
+
+    const contextValue = useMemo<GroupContextValue>(
+        () => ({
+            activeKey,
+            footerSize,
+            headerSize,
+            horizontal: !!horizontal,
+            layout,
+            registerLayer,
+            sharedScrollerRef,
+        }),
+        [activeKey, footerSize, headerSize, horizontal, layout, registerLayer],
+    );
+
+    const onLayout = useCallback(
+        (event: { nativeEvent: { layout: LayoutRectangle } }) => {
+            setLayout(event.nativeEvent.layout);
+            onLayoutProp?.(event as any);
+        },
+        [onLayoutProp],
+    );
+
+    const onScroll = useCallback(
+        (event: NativeSyntheticEvent<NativeScrollEvent>) => {
+            const offset = getScrollOffset(event, !!horizontal);
+            savedOffsets.current.set(activeKeyRef.current, offset);
+            layerRegistrations.current.get(activeKeyRef.current)?.onScroll?.(event);
+            onScrollProp?.(event as any);
+        },
+        [horizontal, onScrollProp],
+    );
+
+    const onMomentumScrollEndInternal = useCallback(
+        (event: NativeSyntheticEvent<NativeScrollEvent>) => {
+            layerRegistrations.current.get(activeKeyRef.current)?.onMomentumScrollEnd?.(event);
+            onMomentumScrollEnd?.(event as any);
+        },
+        [onMomentumScrollEnd],
+    );
+
+    useLayoutEffect(() => {
+        if (ListHeaderComponent) {
+            if (sharedProps.estimatedHeaderSize !== undefined) {
+                setHeaderSize(sharedProps.estimatedHeaderSize);
+            }
+        } else {
+            setHeaderSize(0);
+        }
+    }, [ListHeaderComponent, sharedProps.estimatedHeaderSize]);
+
+    useLayoutEffect(() => {
+        if (!ListFooterComponent) {
+            setFooterSize(0);
+        }
+    }, [ListFooterComponent]);
+
+    useImperativeHandle(forwardedRef, () => {
+        const activeRef = () => listRefs.current.get(activeKeyRef.current);
+        const nativeRef = () => sharedScrollerRef.current ?? activeRef()?.getNativeScrollRef();
+        return {
+            clearCaches: (options) => activeRef()?.clearCaches(options),
+            flashScrollIndicators: () => nativeRef()?.flashScrollIndicators?.(),
+            getNativeScrollRef: () => nativeRef(),
+            getScrollableNode: () => nativeRef()?.getScrollableNode?.(),
+            getScrollResponder: () => nativeRef()?.getScrollResponder?.(),
+            getState: () => activeRef()?.getState() ?? emptyLegendListState(),
+            reportContentInset: (inset) => activeRef()?.reportContentInset(inset),
+            scrollIndexIntoView: (params) => activeRef()?.scrollIndexIntoView(params) ?? Promise.resolve(),
+            scrollItemIntoView: (params) => activeRef()?.scrollItemIntoView(params) ?? Promise.resolve(),
+            scrollToEnd: (options) => activeRef()?.scrollToEnd(options) ?? Promise.resolve(),
+            scrollToIndex: (params) => activeRef()?.scrollToIndex(params) ?? Promise.resolve(),
+            scrollToItem: (params) => activeRef()?.scrollToItem(params) ?? Promise.resolve(),
+            scrollToOffset: (params) => activeRef()?.scrollToOffset(params) ?? Promise.resolve(),
+            setScrollProcessingEnabled: (enabled) => activeRef()?.setScrollProcessingEnabled(enabled),
+            setVisibleContentAnchorOffset: (value) => activeRef()?.setVisibleContentAnchorOffset(value),
+        };
+    }, []);
+
+    const ScrollComponent = useMemo(
+        () =>
+            React.forwardRef((scrollProps: LooseScrollViewProps, ref) => {
+                const render = renderScrollComponentRef.current;
+                if (render) {
+                    return render({ ...scrollProps, ref } as LooseScrollViewProps);
+                }
+                return React.createElement(ListComponentScrollView as React.ComponentType<any>, {
+                    ...scrollProps,
+                    ref,
+                });
+            }),
+        [],
+    );
+
+    const refreshControlElement = refreshControl as React.ReactElement<{ progressViewOffset?: number }> | undefined;
+    const contentContainerStyle = StyleSheet.flatten(contentContainerStyleProp) as ViewStyle | undefined;
+    const style = StyleSheet.flatten(styleProp) as ViewStyle | undefined;
+
+    return (
+        <GroupContext.Provider value={contextValue}>
+            <ScrollComponent
+                {...(sharedProps as any)}
+                contentContainerStyle={[
+                    horizontal
+                        ? {
+                              height: "100%",
+                          }
+                        : {},
+                    contentContainerStyle,
+                ]}
+                horizontal={!!horizontal}
+                maintainVisibleContentPosition={
+                    activeMaintainVisibleContentPosition.size || activeMaintainVisibleContentPosition.data
+                        ? { minIndexForVisible: 0 }
+                        : undefined
+                }
+                onLayout={onLayout as any}
+                onMomentumScrollEnd={onMomentumScrollEndInternal as any}
+                onScroll={onScroll as any}
+                ref={combinedRef as any}
+                refreshControl={
+                    refreshControlElement ??
+                    (onRefresh && <RefreshControl onRefresh={onRefresh} refreshing={!!refreshing} />)
+                }
+                scrollEventThrottle={scrollEventThrottle ?? 0}
+                snapToOffsets={activeSnapToOffsets}
+                style={style}
+            >
+                {ListHeaderComponent && (
+                    <LayoutView
+                        onLayoutChange={(rect) => setHeaderSize(rect[horizontal ? "width" : "height"])}
+                        style={ListHeaderComponentStyle}
+                    >
+                        {getComponent(ListHeaderComponent)}
+                    </LayoutView>
+                )}
+                {lists.map((list) => (
+                    <GroupLayer
+                        inactiveBehavior={inactiveBehavior}
+                        inactiveUpdateMode={inactiveUpdateMode}
+                        isActive={list.key === activeKey}
+                        key={list.key}
+                        list={list}
+                        listRef={(ref) => setListRef(list.key, ref)}
+                        sharedProps={
+                            {
+                                ...sharedProps,
+                                contentContainerStyle: contentContainerStyleProp,
+                                horizontal,
+                                progressViewOffset,
+                                renderItem: props.renderItem,
+                                style: styleProp,
+                            } as any
+                        }
+                    />
+                ))}
+                {ListFooterComponent && (
+                    <LayoutView
+                        onLayoutChange={(rect) => setFooterSize(rect[horizontal ? "width" : "height"])}
+                        style={ListFooterComponentStyle}
+                    >
+                        {getComponent(ListFooterComponent)}
+                    </LayoutView>
+                )}
+            </ScrollComponent>
+        </GroupContext.Provider>
+    );
+});
+
+export const LegendListGroup = typedMemo(
+    typedForwardRef(function LegendListGroupComponent<ItemT>(
+        props: LegendListGroupPropsBase<ItemT, LooseScrollViewProps>,
+        forwardedRef: ForwardedRef<LegendListRef>,
+    ) {
+        return (
+            <StateProvider>
+                <LegendListGroupInner {...props} ref={forwardedRef} />
+            </StateProvider>
+        );
+    }),
+);

--- a/src/entrypoints/shared.ts
+++ b/src/entrypoints/shared.ts
@@ -1,4 +1,5 @@
 import { LegendList as LegendListImpl } from "@/components/LegendList";
+import { LegendListGroup as LegendListGroupImpl } from "@/components/LegendListGroup";
 import { getStickyPushLimit } from "@/components/stickyPositionUtils";
 import { POSITION_OUT_OF_VIEW } from "@/constants";
 import { IsNewArchitecture } from "@/constants-platform";
@@ -8,6 +9,7 @@ import { typedForwardRef, typedMemo } from "@/types.internal";
 import { getComponent } from "@/utils/getComponent";
 
 export const LegendListRuntime = LegendListImpl;
+export const LegendListGroupRuntime = LegendListGroupImpl;
 
 // Internal bridge exports used by integration entrypoints to avoid duplicating local modules.
 /** @internal */

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,12 @@
 import { LegendList as LegendListImpl } from "@/components/LegendList";
-import type { LegendListComponent } from "@/types.root";
+import { LegendListGroup as LegendListGroupImpl } from "@/components/LegendListGroup";
+import type { LegendListComponent, LegendListGroupComponent } from "@/types.root";
 import { IS_DEV } from "@/utils/devEnvironment";
 
 /** @deprecated Use `@legendapp/list/react-native` or `@legendapp/list/react` for strict typing */
 export const LegendList = LegendListImpl as LegendListComponent;
+/** @deprecated Use `@legendapp/list/react-native` or `@legendapp/list/react` for strict typing */
+export const LegendListGroup = LegendListGroupImpl as LegendListGroupComponent;
 
 export {
     useIsLastItem,

--- a/src/react-native.ts
+++ b/src/react-native.ts
@@ -1,6 +1,7 @@
-import { LegendListRuntime, internal as sharedInternal } from "@/entrypoints/shared";
-import type { LegendListComponent } from "@/types.react-native";
+import { LegendListGroupRuntime, LegendListRuntime, internal as sharedInternal } from "@/entrypoints/shared";
+import type { LegendListComponent, LegendListGroupComponent } from "@/types.react-native";
 export const LegendList = LegendListRuntime as LegendListComponent;
+export const LegendListGroup = LegendListGroupRuntime as LegendListGroupComponent;
 
 /** @internal */
 export const internal = sharedInternal;

--- a/src/react.ts
+++ b/src/react.ts
@@ -1,7 +1,8 @@
-import { LegendListRuntime, internal as sharedInternal } from "@/entrypoints/shared";
-import type { LegendListComponent } from "@/types.web";
+import { LegendListGroupRuntime, LegendListRuntime, internal as sharedInternal } from "@/entrypoints/shared";
+import type { LegendListComponent, LegendListGroupComponent } from "@/types.web";
 
 export const LegendList = LegendListRuntime as LegendListComponent;
+export const LegendListGroup = LegendListGroupRuntime as LegendListGroupComponent;
 
 /** @internal */
 export const internal = sharedInternal;

--- a/src/types.base.ts
+++ b/src/types.base.ts
@@ -75,7 +75,7 @@ interface ChildrenModeProps {
 }
 
 // Shared Legend List specific props
-interface LegendListSpecificProps<ItemT, TItemType extends string | undefined> {
+export interface LegendListSpecificProps<ItemT, TItemType extends string | undefined> {
     /**
      * If true, aligns items at the end of the list.
      * @default false
@@ -428,7 +428,7 @@ export type LegendListGroupInactiveUpdateMode = "eager" | "lazy";
 
 export type LegendListGroupScrollPositionMode = "independent" | "shared";
 
-type LegendListGroupListSpecificProps<ItemT, TItemType extends string | undefined = string | undefined> = Pick<
+export type LegendListGroupListSpecificProps<ItemT, TItemType extends string | undefined = string | undefined> = Pick<
     LegendListSpecificProps<ItemT, TItemType>,
     | "alignItemsAtEnd"
     | "alwaysRender"

--- a/src/types.base.ts
+++ b/src/types.base.ts
@@ -422,6 +422,85 @@ export type LegendListPropsBase<
     LegendListSpecificProps<ItemT, TItemType> &
     (DataModeProps<ItemT, TItemType> | ChildrenModeProps);
 
+export type LegendListGroupInactiveBehavior = "activity" | "hidden" | "unmount";
+
+export type LegendListGroupInactiveUpdateMode = "eager" | "lazy";
+
+export type LegendListGroupScrollPositionMode = "independent" | "shared";
+
+type LegendListGroupListSpecificProps<ItemT, TItemType extends string | undefined = string | undefined> = Pick<
+    LegendListSpecificProps<ItemT, TItemType>,
+    | "alignItemsAtEnd"
+    | "alwaysRender"
+    | "columnWrapperStyle"
+    | "dataVersion"
+    | "drawDistance"
+    | "estimatedItemSize"
+    | "estimatedListSize"
+    | "extraData"
+    | "getEstimatedItemSize"
+    | "getFixedItemSize"
+    | "getItemType"
+    | "initialContainerPoolRatio"
+    | "initialScrollAtEnd"
+    | "initialScrollIndex"
+    | "initialScrollOffset"
+    | "itemsAreEqual"
+    | "ItemSeparatorComponent"
+    | "keyExtractor"
+    | "ListEmptyComponent"
+    | "maintainScrollAtEnd"
+    | "maintainScrollAtEndThreshold"
+    | "maintainVisibleContentPosition"
+    | "onEndReached"
+    | "onEndReachedThreshold"
+    | "onItemSizeChanged"
+    | "onLoad"
+    | "onMetricsChange"
+    | "onScroll"
+    | "onStartReached"
+    | "onStartReachedThreshold"
+    | "onStickyHeaderChange"
+    | "onViewableItemsChanged"
+    | "overrideItemLayout"
+    | "recycleItems"
+    | "snapToIndices"
+    | "stickyHeaderConfig"
+    | "stickyHeaderIndices"
+    | "stickyIndices"
+    | "viewabilityConfig"
+    | "viewabilityConfigCallbackPairs"
+>;
+
+export type LegendListGroupList<ItemT, TItemType extends string | undefined = string | undefined> = Partial<
+    LegendListGroupListSpecificProps<ItemT, TItemType>
+> & {
+    key: string;
+    data: ReadonlyArray<ItemT>;
+    renderItem?: (props: LegendListRenderItemProps<ItemT, TItemType>) => React.ReactNode;
+};
+
+export type LegendListGroupPropsBase<
+    ItemT,
+    TScrollViewProps = Record<string, any>,
+    TItemType extends string | undefined = string | undefined,
+> = Omit<
+    BaseScrollViewProps<TScrollViewProps> & LegendListSpecificProps<ItemT, TItemType>,
+    | "dataVersion"
+    | "ListEmptyComponent"
+    | "onEndReached"
+    | "onStartReached"
+    | "onViewableItemsChanged"
+    | "stickyHeaderIndices"
+> & {
+    activeKey: string;
+    inactiveBehavior?: LegendListGroupInactiveBehavior;
+    inactiveUpdateMode?: LegendListGroupInactiveUpdateMode;
+    lists: ReadonlyArray<LegendListGroupList<ItemT, TItemType>>;
+    renderItem?: (props: LegendListRenderItemProps<ItemT, TItemType>) => React.ReactNode;
+    scrollPositionMode?: LegendListGroupScrollPositionMode;
+};
+
 export interface MaintainVisibleContentPositionConfig<ItemT = any> {
     data?: boolean;
     size?: boolean;

--- a/src/types.internal.ts
+++ b/src/types.internal.ts
@@ -16,7 +16,7 @@ import type {
 } from "@/types.base";
 import type { StylesAsSharedValue } from "@/typesInternal";
 
-export type { BaseScrollViewProps, LegendListPropsBase } from "@/types.base";
+export type { BaseScrollViewProps, LegendListGroupPropsBase, LegendListPropsBase } from "@/types.base";
 
 export interface ScrollEventTargetLike {
     addEventListener(type: string, listener: (...args: any[]) => void): void;

--- a/src/types.react-native.ts
+++ b/src/types.react-native.ts
@@ -13,7 +13,7 @@ import type {
 } from "react-native";
 
 import type { LegendListRef as LegendListRefBase, LegendListState as LegendListStateBase } from "@/types.base";
-import type { LegendListPropsBase } from "@/types.internal";
+import type { LegendListGroupPropsBase, LegendListPropsBase } from "@/types.internal";
 
 export type {
     AlwaysRenderConfig,
@@ -22,6 +22,10 @@ export type {
     Insets,
     LayoutRectangle,
     LegendListAverageItemSize,
+    LegendListGroupInactiveBehavior,
+    LegendListGroupInactiveUpdateMode,
+    LegendListGroupList,
+    LegendListGroupScrollPositionMode,
     LegendListMetrics,
     LegendListRecyclingState,
     LegendListRenderItemProps,
@@ -69,6 +73,28 @@ export type LegendListProps<
     TItemType extends string | undefined = string | undefined,
 > = LegendListPropsOverrides<ItemT, TItemType>;
 
+type LegendListGroupPropsOverrides<ItemT, TItemType extends string | undefined> = Omit<
+    LegendListGroupPropsBase<ItemT, ScrollViewProps, TItemType>,
+    | "anchoredEndSpace"
+    | "contentInsetEndAdjustment"
+    | "onScroll"
+    | "refScrollView"
+    | "renderScrollComponent"
+    | "ListHeaderComponentStyle"
+    | "ListFooterComponentStyle"
+> & {
+    onScroll?: (event: NativeSyntheticEvent<NativeScrollEvent>) => void;
+    refScrollView?: React.Ref<ScrollView>;
+    renderScrollComponent?: (props: ScrollViewProps) => React.ReactElement<ScrollViewProps>;
+    ListHeaderComponentStyle?: StyleProp<ViewStyle> | undefined;
+    ListFooterComponentStyle?: StyleProp<ViewStyle> | undefined;
+};
+
+export type LegendListGroupProps<
+    ItemT = any,
+    TItemType extends string | undefined = string | undefined,
+> = LegendListGroupPropsOverrides<ItemT, TItemType>;
+
 export type LegendListRef = Omit<
     LegendListRefBase,
     "getNativeScrollRef" | "getScrollResponder" | "reportContentInset"
@@ -84,4 +110,8 @@ export type LegendListState = Omit<LegendListStateBase, "elementAtIndex"> & {
 
 export type LegendListComponent = <ItemT = any>(
     props: LegendListProps<ItemT> & React.RefAttributes<LegendListRef>,
+) => React.ReactElement | null;
+
+export type LegendListGroupComponent = <ItemT = any>(
+    props: LegendListGroupProps<ItemT> & React.RefAttributes<LegendListRef>,
 ) => React.ReactElement | null;

--- a/src/types.root.ts
+++ b/src/types.root.ts
@@ -40,6 +40,12 @@ export type LegendListPropsBase<
     TItemType extends string | undefined = string | undefined,
 > = InternalTypes.LegendListPropsBase<ItemT, TScrollViewProps, TItemType>;
 /** @deprecated Use `@legendapp/list/react-native` or `@legendapp/list/react` for strict typing */
+export type LegendListGroupPropsBase<
+    ItemT,
+    TScrollViewProps = Record<string, any>,
+    TItemType extends string | undefined = string | undefined,
+> = BaseTypes.LegendListGroupPropsBase<ItemT, TScrollViewProps, TItemType>;
+/** @deprecated Use `@legendapp/list/react-native` or `@legendapp/list/react` for strict typing */
 export type MaintainVisibleContentPositionConfig<ItemT = any> = BaseTypes.MaintainVisibleContentPositionConfig<ItemT>;
 /** @deprecated Use `@legendapp/list/react-native` or `@legendapp/list/react` for strict typing */
 export type AnchoredEndSpaceConfig = BaseTypes.AnchoredEndSpaceConfig;
@@ -58,6 +64,17 @@ export type MaintainScrollAtEndOptions = BaseTypes.MaintainScrollAtEndOptions;
 export type ColumnWrapperStyle = BaseTypes.ColumnWrapperStyle;
 /** @deprecated Use `@legendapp/list/react-native` or `@legendapp/list/react` for strict typing */
 export type LegendListMetrics = BaseTypes.LegendListMetrics;
+/** @deprecated Use `@legendapp/list/react-native` or `@legendapp/list/react` for strict typing */
+export type LegendListGroupInactiveBehavior = BaseTypes.LegendListGroupInactiveBehavior;
+/** @deprecated Use `@legendapp/list/react-native` or `@legendapp/list/react` for strict typing */
+export type LegendListGroupInactiveUpdateMode = BaseTypes.LegendListGroupInactiveUpdateMode;
+/** @deprecated Use `@legendapp/list/react-native` or `@legendapp/list/react` for strict typing */
+export type LegendListGroupScrollPositionMode = BaseTypes.LegendListGroupScrollPositionMode;
+/** @deprecated Use `@legendapp/list/react-native` or `@legendapp/list/react` for strict typing */
+export type LegendListGroupList<
+    ItemT,
+    TItemType extends string | undefined = string | undefined,
+> = BaseTypes.LegendListGroupList<ItemT, TItemType>;
 /** @deprecated Use `@legendapp/list/react-native` or `@legendapp/list/react` for strict typing */
 export type LegendListAverageItemSize = BaseTypes.LegendListAverageItemSize;
 /** @deprecated Use `@legendapp/list/react-native` or `@legendapp/list/react` for strict typing */
@@ -342,7 +359,23 @@ type LegendListPropsLoose<ItemT = any> = Omit<
 /** @deprecated Use `@legendapp/list/react-native` or `@legendapp/list/react` for strict typing */
 export type LegendListProps<ItemT = any> = LegendListPropsLoose<ItemT>;
 
+type LegendListGroupPropsLoose<ItemT = any> = Omit<
+    LegendListGroupPropsBase<ItemT, LooseScrollViewProps>,
+    "ListHeaderComponentStyle" | "ListFooterComponentStyle"
+> & {
+    ListHeaderComponentStyle?: StyleProp<ViewStyle> | CSSProperties | undefined;
+    ListFooterComponentStyle?: StyleProp<ViewStyle> | CSSProperties | undefined;
+};
+
+/** @deprecated Use `@legendapp/list/react-native` or `@legendapp/list/react` for strict typing */
+export type LegendListGroupProps<ItemT = any> = LegendListGroupPropsLoose<ItemT>;
+
 /** @deprecated Use `@legendapp/list/react-native` or `@legendapp/list/react` for strict typing */
 export type LegendListComponent = <ItemT = any>(
     props: LegendListProps<ItemT> & RefAttributes<LegendListRef>,
+) => ReactElement | null;
+
+/** @deprecated Use `@legendapp/list/react-native` or `@legendapp/list/react` for strict typing */
+export type LegendListGroupComponent = <ItemT = any>(
+    props: LegendListGroupProps<ItemT> & RefAttributes<LegendListRef>,
 ) => ReactElement | null;

--- a/src/types.web.ts
+++ b/src/types.web.ts
@@ -4,6 +4,7 @@ import type { ScrollViewMethods } from "@/components/ListComponentScrollView";
 import type { LooseLayoutChangeEvent, LooseScrollViewProps } from "@/platform/scrollview-types";
 import type {
     AnchoredEndSpaceConfig as AnchoredEndSpaceConfigBase,
+    LegendListGroupPropsBase,
     LegendListRef as LegendListRefBase,
     LegendListState as LegendListStateBase,
     NativeScrollEvent,
@@ -18,6 +19,10 @@ export type {
     Insets,
     LayoutRectangle,
     LegendListAverageItemSize,
+    LegendListGroupInactiveBehavior,
+    LegendListGroupInactiveUpdateMode,
+    LegendListGroupList,
+    LegendListGroupScrollPositionMode,
     LegendListMetrics,
     LegendListRecyclingState,
     LegendListRenderItemProps,
@@ -86,6 +91,28 @@ export type LegendListProps<
     TItemType extends string | undefined = string | undefined,
 > = LegendListPropsOverrides<ItemT, TItemType>;
 
+type LegendListGroupPropsOverrides<ItemT, TItemType extends string | undefined> = Omit<
+    LegendListGroupPropsBase<ItemT, ScrollViewPropsWeb, TItemType>,
+    | "anchoredEndSpace"
+    | "refScrollView"
+    | "renderScrollComponent"
+    | "ListHeaderComponentStyle"
+    | "ListFooterComponentStyle"
+    | "onRefresh"
+    | "progressViewOffset"
+    | "refreshing"
+> & {
+    anchoredEndSpace?: AnchoredEndSpaceConfig;
+    refScrollView?: Ref<HTMLElement | ScrollViewMethods>;
+    ListHeaderComponentStyle?: CSSProperties | undefined;
+    ListFooterComponentStyle?: CSSProperties | undefined;
+};
+
+export type LegendListGroupProps<
+    ItemT = any,
+    TItemType extends string | undefined = string | undefined,
+> = LegendListGroupPropsOverrides<ItemT, TItemType>;
+
 export type LegendListRef = Omit<
     LegendListRefBase,
     "getNativeScrollRef" | "getScrollableNode" | "getScrollResponder"
@@ -101,4 +128,8 @@ export type LegendListState = Omit<LegendListStateBase, "elementAtIndex"> & {
 
 export type LegendListComponent = <ItemT = any>(
     props: LegendListProps<ItemT> & RefAttributes<LegendListRef>,
+) => ReactElement | null;
+
+export type LegendListGroupComponent = <ItemT = any>(
+    props: LegendListGroupProps<ItemT> & RefAttributes<LegendListRef>,
 ) => ReactElement | null;


### PR DESCRIPTION
## Summary

Adds `LegendListGroup`, a grouped-list component for multiple independently virtualized LegendList instances that share one outer scroll container.

## How it works

- `LegendListGroup` receives an `activeKey` and a `lists` array. Each list entry has its own `key`, `data`, optional `renderItem`, and supported per-list LegendList configuration.
- The group renders one outer scroll component with the shared `ListHeaderComponent`, list layers, and shared `ListFooterComponent` as siblings.
- Each list layer renders a real `LegendList`, but replaces its internal scroll component with a lightweight layer component that registers that list's `onScroll`, `onMomentumScrollEnd`, and snap offsets with the group.
- The outer shared scroll component forwards scroll events only to the currently active list, then calls the group-level `onScroll`.
- The forwarded group ref delegates imperative methods and `getState()` to the currently active list ref.
- Inactive lists remain mounted by default with hidden absolute positioning so their virtualization state can be preserved without contributing visible content.
- Inactive list prop updates are lazy by default: inactive list entries keep their previously committed props until they become active. `inactiveUpdateMode="eager"` opts into updating inactive lists immediately.
- `inactiveBehavior` controls inactive rendering: `hidden` keeps inactive lists mounted and hidden, `activity` wraps them in React Activity when available, and `unmount` removes inactive lists from the tree.
- The active list's `maintainVisibleContentPosition` controls whether the shared outer scroll component receives native MVCP.
- Shared header/footer sizes are measured once by the group and written into each list's current state context so list positioning accounts for shared chrome.
- `scrollPositionMode="independent"` stores the last observed offset per list key and restores that offset when switching back to a list. `scrollPositionMode="shared"` leaves the current scroll offset unchanged when switching active lists.

## Public API

- Exports `LegendListGroup` from root, `/react`, and `/react-native` entrypoints.
- Adds `LegendListGroupProps`, `LegendListGroupList`, `LegendListGroupInactiveBehavior`, `LegendListGroupInactiveUpdateMode`, and `LegendListGroupScrollPositionMode` public types.
- Uses `activeKey` and `lists`; this does not add child-based grouped list APIs.
- Does not support per-list `numColumns` in this implementation.

## Tests

- `bun test __tests__/components/LegendListGroup.test.tsx`
- `bun run tsc:src` was run and still fails on existing unrelated errors in keyboard, reanimated, react-dom platform resolution, and LayoutView.native ref typing.