### PR TITLE
fix: batch globalResizeObserver callbacks via requestAnimationFrame

### DIFF
--- a/__tests__/hooks/createResizeObserver.test.ts
+++ b/__tests__/hooks/createResizeObserver.test.ts
@@ -4,17 +4,20 @@ import { createResizeObserver } from "../../src/hooks/createResizeObserver";
 
 // The globalResizeObserver singleton is created lazily on first call and reused.
 // We capture the ResizeObserver callback on the first createResizeObserver call,
-// then trigger it directly in each test. rAF is mocked per-test so each test
-// controls exactly when the frame fires.
+// then trigger it directly in each test. setTimeout is mocked per-test so each test
+// controls exactly when the debounced flush fires.
 
 let capturedResizeCallback: ResizeObserverCallback | null = null;
-let rafCallbacks: FrameRequestCallback[] = [];
-let originalRaf: typeof requestAnimationFrame;
+let timerCallbacks: Map<number, () => void> = new Map();
+let timerIdCounter = 0;
+let originalSetTimeout: typeof setTimeout;
+let originalClearTimeout: typeof clearTimeout;
 let originalResizeObserver: typeof ResizeObserver;
 
 // Install mocks before the singleton is created (i.e., at module load time).
 // These run before any test, so the singleton picks up our MockResizeObserver.
-originalRaf = globalThis.requestAnimationFrame;
+originalSetTimeout = globalThis.setTimeout;
+originalClearTimeout = globalThis.clearTimeout;
 originalResizeObserver = globalThis.ResizeObserver;
 
 globalThis.ResizeObserver = class MockResizeObserver {
@@ -30,22 +33,29 @@ globalThis.ResizeObserver = class MockResizeObserver {
 const _initEl = {} as Element;
 createResizeObserver(_initEl, () => {});
 
-describe("createResizeObserver - rAF batching", () => {
+describe("createResizeObserver - debounce batching", () => {
     beforeEach(() => {
-        rafCallbacks = [];
-        globalThis.requestAnimationFrame = ((cb: FrameRequestCallback) => {
-            rafCallbacks.push(cb);
-            return rafCallbacks.length;
-        }) as typeof requestAnimationFrame;
+        timerCallbacks = new Map();
+        timerIdCounter = 0;
+        globalThis.setTimeout = ((cb: () => void, _delay: number) => {
+            const id = ++timerIdCounter;
+            timerCallbacks.set(id, cb);
+            return id;
+        }) as unknown as typeof setTimeout;
+        globalThis.clearTimeout = ((id: number) => {
+            timerCallbacks.delete(id);
+        }) as unknown as typeof clearTimeout;
     });
 
     afterEach(() => {
-        globalThis.requestAnimationFrame = originalRaf;
+        globalThis.setTimeout = originalSetTimeout;
+        globalThis.clearTimeout = originalClearTimeout;
     });
 
-    function flushRaf() {
-        const cbs = rafCallbacks.splice(0);
-        for (const cb of cbs) cb(0);
+    function flushTimers() {
+        const cbs = [...timerCallbacks.values()];
+        timerCallbacks.clear();
+        for (const cb of cbs) cb();
     }
 
     function fireObserver(entries: Partial<ResizeObserverEntry>[]) {
@@ -61,13 +71,13 @@ describe("createResizeObserver - rAF batching", () => {
 
         expect(callback).not.toHaveBeenCalled();
 
-        flushRaf();
+        flushTimers();
 
         expect(callback).toHaveBeenCalledTimes(1);
         unsub();
     });
 
-    it("schedules only one rAF for multiple synchronous observer firings", () => {
+    it("schedules only one timer for multiple synchronous observer firings", () => {
         const element = {} as Element;
         const callback = mock(() => {});
         const unsub = createResizeObserver(element, callback);
@@ -75,15 +85,15 @@ describe("createResizeObserver - rAF batching", () => {
         fireObserver([{ target: element }]);
         fireObserver([{ target: element }]);
 
-        expect(rafCallbacks).toHaveLength(1);
+        expect(timerCallbacks.size).toBe(1);
 
-        flushRaf();
+        flushTimers();
 
         expect(callback).toHaveBeenCalledTimes(2);
         unsub();
     });
 
-    it("processes entries from all firings that arrived before the rAF", () => {
+    it("processes entries from all firings that arrived before the timer", () => {
         const el1 = {} as Element;
         const el2 = {} as Element;
         const cb1 = mock(() => {});
@@ -93,7 +103,7 @@ describe("createResizeObserver - rAF batching", () => {
 
         fireObserver([{ target: el1 }, { target: el2 }]);
 
-        flushRaf();
+        flushTimers();
 
         expect(cb1).toHaveBeenCalledTimes(1);
         expect(cb2).toHaveBeenCalledTimes(1);
@@ -101,31 +111,31 @@ describe("createResizeObserver - rAF batching", () => {
         unsub2();
     });
 
-    it("does not call callbacks for elements that were unsubscribed before rAF fires", () => {
+    it("does not call callbacks for elements that were unsubscribed before timer fires", () => {
         const element = {} as Element;
         const callback = mock(() => {});
         const unsub = createResizeObserver(element, callback);
 
         fireObserver([{ target: element }]);
         unsub();
-        flushRaf();
+        flushTimers();
 
         expect(callback).not.toHaveBeenCalled();
     });
 
-    it("allows a new rAF to be scheduled after the previous one fires", () => {
+    it("allows a new timer to be scheduled after the previous one fires", () => {
         const element = {} as Element;
         const callback = mock(() => {});
         const unsub = createResizeObserver(element, callback);
 
         fireObserver([{ target: element }]);
-        flushRaf();
+        flushTimers();
         expect(callback).toHaveBeenCalledTimes(1);
 
-        // Second batch after first rAF completes
+        // Second batch after first timer completes
         fireObserver([{ target: element }]);
-        expect(rafCallbacks).toHaveLength(1);
-        flushRaf();
+        expect(timerCallbacks.size).toBe(1);
+        flushTimers();
         expect(callback).toHaveBeenCalledTimes(2);
 
         unsub();

--- a/__tests__/hooks/createResizeObserver.test.ts
+++ b/__tests__/hooks/createResizeObserver.test.ts
@@ -1,0 +1,133 @@
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
+import "../setup";
+import { createResizeObserver } from "../../src/hooks/createResizeObserver";
+
+// The globalResizeObserver singleton is created lazily on first call and reused.
+// We capture the ResizeObserver callback on the first createResizeObserver call,
+// then trigger it directly in each test. rAF is mocked per-test so each test
+// controls exactly when the frame fires.
+
+let capturedResizeCallback: ResizeObserverCallback | null = null;
+let rafCallbacks: FrameRequestCallback[] = [];
+let originalRaf: typeof requestAnimationFrame;
+let originalResizeObserver: typeof ResizeObserver;
+
+// Install mocks before the singleton is created (i.e., at module load time).
+// These run before any test, so the singleton picks up our MockResizeObserver.
+originalRaf = globalThis.requestAnimationFrame;
+originalResizeObserver = globalThis.ResizeObserver;
+
+globalThis.ResizeObserver = class MockResizeObserver {
+    constructor(cb: ResizeObserverCallback) {
+        capturedResizeCallback = cb;
+    }
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+} as unknown as typeof ResizeObserver;
+
+// Trigger singleton creation so capturedResizeCallback is set.
+const _initEl = {} as Element;
+createResizeObserver(_initEl, () => {});
+
+describe("createResizeObserver - rAF batching", () => {
+    beforeEach(() => {
+        rafCallbacks = [];
+        globalThis.requestAnimationFrame = ((cb: FrameRequestCallback) => {
+            rafCallbacks.push(cb);
+            return rafCallbacks.length;
+        }) as typeof requestAnimationFrame;
+    });
+
+    afterEach(() => {
+        globalThis.requestAnimationFrame = originalRaf;
+    });
+
+    function flushRaf() {
+        const cbs = rafCallbacks.splice(0);
+        for (const cb of cbs) cb(0);
+    }
+
+    function fireObserver(entries: Partial<ResizeObserverEntry>[]) {
+        capturedResizeCallback!(entries as ResizeObserverEntry[], {} as ResizeObserver);
+    }
+
+    it("does not invoke callbacks synchronously when ResizeObserver fires", () => {
+        const element = {} as Element;
+        const callback = mock(() => {});
+        const unsub = createResizeObserver(element, callback);
+
+        fireObserver([{ target: element }]);
+
+        expect(callback).not.toHaveBeenCalled();
+
+        flushRaf();
+
+        expect(callback).toHaveBeenCalledTimes(1);
+        unsub();
+    });
+
+    it("schedules only one rAF for multiple synchronous observer firings", () => {
+        const element = {} as Element;
+        const callback = mock(() => {});
+        const unsub = createResizeObserver(element, callback);
+
+        fireObserver([{ target: element }]);
+        fireObserver([{ target: element }]);
+
+        expect(rafCallbacks).toHaveLength(1);
+
+        flushRaf();
+
+        expect(callback).toHaveBeenCalledTimes(2);
+        unsub();
+    });
+
+    it("processes entries from all firings that arrived before the rAF", () => {
+        const el1 = {} as Element;
+        const el2 = {} as Element;
+        const cb1 = mock(() => {});
+        const cb2 = mock(() => {});
+        const unsub1 = createResizeObserver(el1, cb1);
+        const unsub2 = createResizeObserver(el2, cb2);
+
+        fireObserver([{ target: el1 }, { target: el2 }]);
+
+        flushRaf();
+
+        expect(cb1).toHaveBeenCalledTimes(1);
+        expect(cb2).toHaveBeenCalledTimes(1);
+        unsub1();
+        unsub2();
+    });
+
+    it("does not call callbacks for elements that were unsubscribed before rAF fires", () => {
+        const element = {} as Element;
+        const callback = mock(() => {});
+        const unsub = createResizeObserver(element, callback);
+
+        fireObserver([{ target: element }]);
+        unsub();
+        flushRaf();
+
+        expect(callback).not.toHaveBeenCalled();
+    });
+
+    it("allows a new rAF to be scheduled after the previous one fires", () => {
+        const element = {} as Element;
+        const callback = mock(() => {});
+        const unsub = createResizeObserver(element, callback);
+
+        fireObserver([{ target: element }]);
+        flushRaf();
+        expect(callback).toHaveBeenCalledTimes(1);
+
+        // Second batch after first rAF completes
+        fireObserver([{ target: element }]);
+        expect(rafCallbacks).toHaveLength(1);
+        flushRaf();
+        expect(callback).toHaveBeenCalledTimes(2);
+
+        unsub();
+    });
+});

--- a/src/hooks/createResizeObserver.ts
+++ b/src/hooks/createResizeObserver.ts
@@ -2,14 +2,25 @@ let globalResizeObserver: ResizeObserver | null = null;
 
 function getGlobalResizeObserver(): ResizeObserver {
     if (!globalResizeObserver) {
+        let pending: ResizeObserverEntry[] = [];
+        let ticking = false;
         globalResizeObserver = new ResizeObserver((entries) => {
-            for (const entry of entries) {
-                const callbacks = callbackMap.get(entry.target);
-                if (callbacks) {
-                    for (const callback of callbacks) {
-                        callback(entry);
+            pending = pending.concat(entries);
+            if (!ticking) {
+                ticking = true;
+                requestAnimationFrame(() => {
+                    const toProcess = pending;
+                    pending = [];
+                    ticking = false;
+                    for (const entry of toProcess) {
+                        const callbacks = callbackMap.get(entry.target);
+                        if (callbacks) {
+                            for (const callback of callbacks) {
+                                callback(entry);
+                            }
+                        }
                     }
-                }
+                });
             }
         });
     }

--- a/src/hooks/createResizeObserver.ts
+++ b/src/hooks/createResizeObserver.ts
@@ -3,25 +3,23 @@ let globalResizeObserver: ResizeObserver | null = null;
 function getGlobalResizeObserver(): ResizeObserver {
     if (!globalResizeObserver) {
         let pending: ResizeObserverEntry[] = [];
-        let ticking = false;
+        let timer: ReturnType<typeof setTimeout> | null = null;
         globalResizeObserver = new ResizeObserver((entries) => {
             pending = pending.concat(entries);
-            if (!ticking) {
-                ticking = true;
-                requestAnimationFrame(() => {
-                    const toProcess = pending;
-                    pending = [];
-                    ticking = false;
-                    for (const entry of toProcess) {
-                        const callbacks = callbackMap.get(entry.target);
-                        if (callbacks) {
-                            for (const callback of callbacks) {
-                                callback(entry);
-                            }
+            clearTimeout(timer!);
+            timer = setTimeout(() => {
+                const toProcess = pending;
+                pending = [];
+                timer = null;
+                for (const entry of toProcess) {
+                    const callbacks = callbackMap.get(entry.target);
+                    if (callbacks) {
+                        for (const callback of callbacks) {
+                            callback(entry);
                         }
                     }
-                });
-            }
+                }
+            }, 0);
         });
     }
     return globalResizeObserver;


### PR DESCRIPTION
Hi, 

I've been using 3.0.0-beta.56 and I ran into an issue w/ my list on web (electron). If i set my drawDistance higher when going into my chat app I'd get a 'ResizeObserver loop completed with undelivered notifications' error immediately. This fixes it for me.

AI summary below:

```
Calling ResizeObserver callbacks synchronously causes "ResizeObserver loop completed with undelivered notifications" errors in browsers/Electron when a callback triggers layout changes that generate new resize observations before the current notification batch is fully delivered.

Defer callback dispatch through requestAnimationFrame, coalescing all entries that arrive within the same frame into a single flush. This matches the standard pattern for ResizeObserver implementations and eliminates the loop error without changing observable behavior for callers.```