### PR TITLE
fix: showsVerticalScrollIndicator={false} not working on web

### DIFF
--- a/__tests__/components/ListComponentScrollView.web.test.tsx
+++ b/__tests__/components/ListComponentScrollView.web.test.tsx
@@ -629,11 +629,13 @@ describe("ListComponentScrollView (web)", () => {
 
             expect(appendChild).toHaveBeenCalledWith(styleElement);
             expect(styleElement.id).toBe("legend-list-scrollbar-axis-hidden-style");
+            // Firefox / legacy Edge hide the scrollbar via these element-level rules.
             expect(styleElement.textContent).toContain(
-                ".legend-list-scrollbar-y-hidden::-webkit-scrollbar:vertical{width:0;display:none;}",
+                ".legend-list-scrollbar-y-hidden,.legend-list-scrollbar-x-hidden{scrollbar-width:none;-ms-overflow-style:none;}",
             );
+            // WebKit (Chrome/Safari) hides via the ::-webkit-scrollbar pseudo-element.
             expect(styleElement.textContent).toContain(
-                ".legend-list-scrollbar-x-hidden::-webkit-scrollbar:horizontal{height:0;display:none;}",
+                ".legend-list-scrollbar-y-hidden::-webkit-scrollbar,.legend-list-scrollbar-x-hidden::-webkit-scrollbar{width:0;height:0;display:none;}",
             );
         } finally {
             act(() => {

--- a/example-web/src/catalogMeta.ts
+++ b/example-web/src/catalogMeta.ts
@@ -100,6 +100,11 @@ export const FIXTURE_SECTIONS: CatalogSection[] = [
                 title: "Prepend Large Items Jump",
             },
             {
+                description: "Repro: prepending older messages breaks maintain-visible-content-position.",
+                slug: "prepend-mvcp-jump",
+                title: "Prepend MVCP Jump",
+            },
+            {
                 description: "Exercises web CSS snapping for virtualized horizontal snap targets.",
                 slug: "snap-to-indices",
                 title: "Snap To Indices",

--- a/example-web/src/fixtures/PrependMvcpJumpExample.tsx
+++ b/example-web/src/fixtures/PrependMvcpJumpExample.tsx
@@ -1,0 +1,147 @@
+import { useMemo, useRef, useState } from "react";
+
+import { LegendList, type LegendListRef } from "@legendapp/list/react";
+
+/**
+ * Reproducible sandbox for the LegendList open-scroll jump on prepend.
+ *
+ * The item heights and the list rect below were captured from a real app
+ * (a conversation that exhibits a scroll jump when older messages load). The
+ * list is positioned at the exact same screen geometry so the configuration
+ * matches.
+ *
+ * Repro:
+ *  1. Tap "Remount" — list opens at the last item of the initial page.
+ *  2. Tap "Load older" — the older items are prepended.
+ *
+ * Expected: with `maintainVisibleContentPosition`, the currently visible row
+ * should stay put when older items are prepended.
+ * Bug: the scroll position is NOT maintained on that prepend.
+ */
+const ITEM_HEIGHTS = [
+    { height: 48.09027862548828, index: 0, width: 818.3333740234375 },
+    { height: 45.659725189208984, index: 1, width: 818.3333740234375 },
+    { height: 37.65625, index: 2, width: 818.3333740234375 },
+    { height: 37.65625, index: 3, width: 818.3333740234375 },
+    { height: 37.65625, index: 4, width: 818.3333740234375 },
+    { height: 37.65625, index: 5, width: 818.3333740234375 },
+    { height: 37.65625, index: 6, width: 818.3333740234375 },
+    { height: 37.65625, index: 7, width: 818.3333740234375 },
+    { height: 37.65625, index: 8, width: 818.3333740234375 },
+    { height: 37.65625, index: 9, width: 818.3333740234375 },
+    { height: 37.65625, index: 10, width: 818.3333740234375 },
+    { height: 37.65625, index: 11, width: 818.3333740234375 },
+    { height: 425.9895935058594, index: 12, width: 818.3333740234375 },
+    { height: 68.54167175292969, index: 13, width: 818.3333740234375 },
+    { height: 37.65625, index: 14, width: 818.3333740234375 },
+    { height: 48.09027862548828, index: 15, width: 818.3333740234375 },
+    { height: 434.8871765136719, index: 16, width: 818.3333740234375 },
+    { height: 48.09027862548828, index: 17, width: 818.3333740234375 },
+    { height: 68.54167175292969, index: 18, width: 818.3333740234375 },
+    { height: 37.65625, index: 19, width: 818.3333740234375 },
+].map((it) => it.height);
+
+const LIST_RECT = {
+    height: 817.9166870117188,
+    width: 1218.3333740234375,
+    x: 460.5555725097656,
+    y: 49.548614501953125,
+};
+
+interface Item {
+    id: string;
+    index: number;
+    height: number;
+}
+
+const DATA: Array<Item> = ITEM_HEIGHTS.map((height, index) => ({
+    height,
+    id: `item-${index}`,
+    index,
+}));
+
+// We first show only the last N items (the "last page"), then prepend the
+// older ones — mirroring how the app opens at the end and then loads older
+// messages. The bug appears on that prepend (MVCP re-anchoring).
+const INITIAL_COUNT = 13;
+const INITIAL_LAST_INDEX = INITIAL_COUNT - 1;
+
+export default function PrependMvcpJumpExample() {
+    const listRef = useRef<LegendListRef>(null);
+    // Remounting re-triggers the initial open; showAll prepends the older items.
+    const [mountKey, setMountKey] = useState(0);
+    const [showAll, setShowAll] = useState(false);
+
+    // Mirror the app workaround: items get fresh refs so LegendList re-renders.
+    // https://github.com/LegendApp/legend-list/issues/455
+    const visibleData = useMemo(() => {
+        const slice = showAll ? DATA : DATA.slice(-INITIAL_COUNT);
+        return slice.map((item) => ({ ...item }));
+    }, [showAll, mountKey]);
+
+    const remount = () => {
+        setShowAll(false);
+        setMountKey((key) => key + 1);
+    };
+
+    return (
+        <div style={{ background: "#ddd", flex: 1, minHeight: 0, position: "relative" }}>
+            <div style={{ display: "flex", flexDirection: "column", gap: 8, left: 12, position: "absolute", top: 12, zIndex: 10 }}>
+                <button onClick={remount} style={{ background: "#333", borderRadius: 6, color: "white", padding: 10 }} type="button">
+                    Remount ({INITIAL_COUNT} last only)
+                </button>
+                <button
+                    onClick={() => setShowAll(true)}
+                    style={{ background: "#1a73e8", borderRadius: 6, color: "white", padding: 10 }}
+                    type="button"
+                >
+                    Load older (prepend {DATA.length - INITIAL_COUNT})
+                </button>
+            </div>
+
+            <div
+                style={{
+                    background: "white",
+                    border: "1px solid red",
+                    boxSizing: "border-box",
+                    display: "flex",
+                    flexDirection: "column",
+                    height: LIST_RECT.height,
+                    left: LIST_RECT.x,
+                    position: "absolute",
+                    top: LIST_RECT.y,
+                    width: LIST_RECT.width,
+                }}
+            >
+                <LegendList<Item>
+                    className="min-h-0 flex-1"
+                    data={visibleData}
+                    initialScrollIndex={{ index: INITIAL_LAST_INDEX, viewPosition: 0 }}
+                    itemsAreEqual={(itA, itB) => itA.id === itB.id}
+                    key={mountKey}
+                    keyExtractor={(item) => item.id}
+                    maintainScrollAtEndThreshold={1}
+                    maintainVisibleContentPosition
+                    recycleItems
+                    ref={listRef}
+                    renderItem={({ item }) => (
+                        <div
+                            style={{
+                                alignItems: "center",
+                                background: item.height > 200 ? "#e8f0fe" : "#fff",
+                                borderBottom: "1px solid #ccc",
+                                boxSizing: "border-box",
+                                display: "flex",
+                                height: item.height,
+                                paddingLeft: 12,
+                                paddingRight: 12,
+                            }}
+                        >
+                            <span>{`#${item.index} · ${Math.round(item.height)}px`}</span>
+                        </div>
+                    )}
+                />
+            </div>
+        </div>
+    );
+}

--- a/example-web/src/fixtures/routes.tsx
+++ b/example-web/src/fixtures/routes.tsx
@@ -20,6 +20,7 @@ import LazyListExample from "./LazyListExample";
 import MutableCellsExample from "./MutableCellsExample";
 import MVCPTestExample from "./MVCPTestExample";
 import PrependLargeItemsJumpExample from "./PrependLargeItemsJumpExample";
+import PrependMvcpJumpExample from "./PrependMvcpJumpExample";
 import SnapToIndicesExample from "./SnapToIndicesExample";
 import WindowScrollExample from "./WindowScrollExample";
 
@@ -144,6 +145,13 @@ export const FIXTURE_ROUTES: FixtureRoute[] = [
         group: "Scroll & Position",
         path: "prepend-large-items-jump",
         title: "Prepend Large Items Jump",
+    },
+    {
+        description: "Repro: prepending older messages breaks maintain-visible-content-position.",
+        element: () => <PrependMvcpJumpExample />,
+        group: "Scroll & Position",
+        path: "prepend-mvcp-jump",
+        title: "Prepend MVCP Jump",
     },
     {
         description: "Exercises web CSS snapping for virtualized horizontal snap targets.",

--- a/src/components/ListComponentScrollView.tsx
+++ b/src/components/ListComponentScrollView.tsx
@@ -91,7 +91,7 @@ interface ExtraPropsFromRN {
 }
 
 const SCROLLBAR_HIDDEN_STYLE_ID = "legend-list-scrollbar-axis-hidden-style";
-const SCROLLBAR_HIDDEN_STYLE = `.${LEGEND_LIST_SCROLLBAR_Y_HIDDEN_CLASS}::-webkit-scrollbar:vertical{width:0;display:none;}.${LEGEND_LIST_SCROLLBAR_X_HIDDEN_CLASS}::-webkit-scrollbar:horizontal{height:0;display:none;}`;
+const SCROLLBAR_HIDDEN_STYLE = `.${LEGEND_LIST_SCROLLBAR_Y_HIDDEN_CLASS},.${LEGEND_LIST_SCROLLBAR_X_HIDDEN_CLASS}{scrollbar-width:none;-ms-overflow-style:none;}.${LEGEND_LIST_SCROLLBAR_Y_HIDDEN_CLASS}::-webkit-scrollbar,.${LEGEND_LIST_SCROLLBAR_X_HIDDEN_CLASS}::-webkit-scrollbar{width:0;height:0;display:none;}`;
 
 function ensureScrollbarHiddenStyle() {
     if (typeof document === "undefined" || document.getElementById(SCROLLBAR_HIDDEN_STYLE_ID)) {


### PR DESCRIPTION
We can't hide verticalScrollIndicator on the web

It is a no-op on most browsers, the injected CSS used ::-webkit-scrollbar:vertical (the :vertical qualifier is unreliable in modern Chrome) and had nothing for Firefox.

<img width="342" height="472" alt="Image" src="https://github.com/user-attachments/assets/91ca5cec-b8a6-4e9b-9ebd-388470e04bf3" />
