### PR TITLE
fix(rtl): horizontal RTL initial scroll mispositions on mount (mirror at end, blank at index 0)

### DIFF
--- a/src/components/LegendList.tsx
+++ b/src/components/LegendList.tsx
@@ -518,7 +518,13 @@ const LegendListInner = typedForwardRef(function LegendListInner<T>(
         }
 
         const resolvedOffset = initialScroll.contentOffset ?? resolveInitialScrollOffset(ctx, initialScroll);
-        return usesBootstrapInitialScroll && state.initialScrollSession?.kind === "bootstrap" && Platform.OS === "web"
+        // For horizontal RTL, this seed is a logical (LTR) offset; feeding it to the
+        // native `contentOffset` unconverted lands on the RTL mirror. Skip the seed
+        // and let the initial-scroll dispatch (which converts) position the list.
+        return (usesBootstrapInitialScroll &&
+            state.initialScrollSession?.kind === "bootstrap" &&
+            Platform.OS === "web") ||
+            isHorizontalRTLProps({ horizontal, rtl })
             ? undefined
             : resolvedOffset;
     }, [usesBootstrapInitialScroll]);

--- a/src/components/LegendList.tsx
+++ b/src/components/LegendList.tsx
@@ -518,13 +518,14 @@ const LegendListInner = typedForwardRef(function LegendListInner<T>(
         }
 
         const resolvedOffset = initialScroll.contentOffset ?? resolveInitialScrollOffset(ctx, initialScroll);
-        // For horizontal RTL, this seed is a logical (LTR) offset; feeding it to the
-        // native `contentOffset` unconverted lands on the RTL mirror. Skip the seed
-        // and let the initial-scroll dispatch (which converts) position the list.
-        return (usesBootstrapInitialScroll &&
-            state.initialScrollSession?.kind === "bootstrap" &&
-            Platform.OS === "web") ||
-            isHorizontalRTLProps({ horizontal, rtl })
+        // For a horizontal RTL *bootstrap* scroll (initialScrollIndex / initialScrollAtEnd),
+        // this seed is a logical (LTR) offset; feeding it to the native `contentOffset`
+        // unconverted lands on the RTL mirror. Skip the seed and let the bootstrap
+        // dispatch (which converts) position the list. Scoped to bootstrap sessions so
+        // offset-only initial scrolls still apply their offset.
+        return usesBootstrapInitialScroll &&
+            ((state.initialScrollSession?.kind === "bootstrap" && Platform.OS === "web") ||
+                isHorizontalRTLProps({ horizontal, rtl }))
             ? undefined
             : resolvedOffset;
     }, [usesBootstrapInitialScroll]);

--- a/src/core/bootstrapInitialScroll.ts
+++ b/src/core/bootstrapInitialScroll.ts
@@ -10,6 +10,7 @@ import { IS_DEV } from "@/utils/devEnvironment";
 import { getId } from "@/utils/getId";
 import { getItemSize } from "@/utils/getItemSize";
 import { requestAdjust } from "@/utils/requestAdjust";
+import { isHorizontalRTL } from "@/utils/rtl";
 
 const DEFAULT_BOOTSTRAP_REVEAL_EPSILON = 1;
 const DEFAULT_BOOTSTRAP_REVEAL_MAX_FRAMES = 8;
@@ -525,6 +526,12 @@ export function startBootstrapInitialScrollOnMount(
     const shouldFinishAtOrigin =
         offset === 0 &&
         !initialScrollAtEnd &&
+        // For a horizontal RTL list a logical offset of 0 is NOT the native origin:
+        // the native ScrollView rests at the opposite (max-offset) edge, so finishing
+        // "at origin" without scrolling leaves the list on the mirror end and the
+        // target index (e.g. initialScrollIndex 0) renders blank. Let the bootstrap
+        // dispatch run so the offset is converted to native RTL coordinates.
+        !isHorizontalRTL(state) &&
         (isOffsetInitialScrollSession(state)
             ? Math.abs(target.contentOffset ?? 0) <= 1
             : target.index === 0 && (target.viewPosition ?? 0) === 0 && Math.abs(target.viewOffset ?? 0) <= 1);

--- a/src/core/bootstrapInitialScroll.ts
+++ b/src/core/bootstrapInitialScroll.ts
@@ -950,6 +950,12 @@ export function evaluateBootstrapInitialScroll(ctx: StateContext) {
     if (
         Platform.OS !== "web" &&
         Platform.OS !== "android" &&
+        // For a horizontal RTL list the mount seed and observed offset are logical 0,
+        // but the native origin is the opposite (max-offset) edge — so "already at the
+        // resolved offset" is a false positive and finishing without a scroll leaves
+        // index 0 blank. Always dispatch for horizontal RTL (which converts logical 0
+        // to the native RTL coordinate). Mirrors the shouldFinishAtOrigin guard above.
+        !isHorizontalRTL(state) &&
         Math.abs(bootstrapInitialScroll.seedContentOffset - resolvedOffset) <= 1 &&
         Math.abs(getObservedBootstrapInitialScrollOffset(state) - resolvedOffset) <= 1
     ) {

--- a/src/core/checkFinishedScroll.ts
+++ b/src/core/checkFinishedScroll.ts
@@ -6,6 +6,7 @@ import { initialScrollCompletion, initialScrollWatchdog } from "@/core/initialSc
 import { Platform } from "@/platform/Platform";
 import { getContentSize } from "@/state/getContentSize";
 import type { StateContext } from "@/state/state";
+import { toNativeHorizontalOffset } from "@/utils/rtl";
 
 type ActiveScrollTarget = NonNullable<StateContext["state"]["scrollingTo"]>;
 const INITIAL_SCROLL_MAX_FALLBACK_CHECKS = 20;
@@ -151,10 +152,16 @@ function checkFinishedScrollFrame(ctx: StateContext) {
 }
 
 function scrollToFallbackOffset(ctx: StateContext, offset: number) {
-    ctx.state.refScroller.current?.scrollTo({
+    const state = ctx.state;
+    const isHorizontal = !!state.props.horizontal;
+    // `offset` is a logical (LTR) offset. The normal dispatch path converts it to
+    // the native RTL coordinate; do the same here so the watchdog/retry doesn't
+    // dispatch an unconverted offset and land on the RTL mirror index.
+    const x = isHorizontal ? toNativeHorizontalOffset(state, offset, getContentSize(ctx)) : 0;
+    state.refScroller.current?.scrollTo({
         animated: false,
-        x: ctx.state.props.horizontal ? offset : 0,
-        y: ctx.state.props.horizontal ? 0 : offset,
+        x,
+        y: isHorizontal ? 0 : offset,
     });
 }
 


### PR DESCRIPTION
Fixes #476.

## Problem

A horizontal **RTL** `LegendList` positions its initial scroll incorrectly on mount. Legend List keeps logical (LTR) scroll offsets and converts to the native RTL coordinate via `toNativeHorizontalOffset`; four spots on the initial-scroll path skipped or bypassed that conversion:

1. **`scrollToFallbackOffset`** (the initial-scroll watchdog/retry in `checkFinishedScroll.ts`) dispatched the **unconverted** logical offset directly to the native `scrollTo`. When the watchdog wins the race against the bootstrap scroll's native `onScroll` round-trip (more likely on a large jump / slow device / with `recycleItems`), a near-the-end `initialScrollIndex` lands on the **mirror** index (e.g. request item 595 of 604 → settles on item 10 = `total − 1 − 594`).
2. The **`initialContentOffset`** seed (the first native `contentOffset`) was also taken unconverted for RTL.
3. **`startBootstrapInitialScrollOnMount`** short-circuits (`shouldFinishAtOrigin` → "finish at origin without scrolling") when the logical target offset is `0`. For horizontal RTL the native origin is the **opposite** edge, so `initialScrollIndex={0}` (a fresh mount at the first item) is **never dispatched** and renders **blank**; the first user scroll then reconciles to the mirror end. This is the low-index counterpart of #1's near-the-end mirror — same subsystem, and the fix depends on #1 (once index 0 stops short-circuiting, its dispatch/retry relies on the converted `scrollToFallbackOffset` to land correctly).
4. **The iOS/macOS "reveal-settle" branch** of the same bootstrap (`Platform.OS !== "web" && !== "android"`) compares the **logical** resolved offset against the seeded/observed **native** contentOffset and, when they match within 1px, calls `finishBootstrapInitialScrollWithoutScroll` — finishing without ever dispatching a scroll. For horizontal RTL, logical `0` and native `0` are **opposite edges**, so `initialScrollIndex={0}` passes the comparison and finishes while the viewport actually sits at the native origin (the *last* item's edge) → blank on iOS even with fixes 1–3 applied (which is why the bug survived on iOS after the Android verification passed: Android always takes the dispatch path here).

## Fix

- Convert the offset in **`scrollToFallbackOffset`** (mirroring the normal `doScrollTo` dispatch).
- Skip the unconverted RTL **`initialContentOffset`** seed so the converting initial-scroll dispatch positions the list.
- Skip the **`shouldFinishAtOrigin`** shortcut for horizontal RTL so index-0 targets flow through the bootstrap dispatch (which converts to native coordinates).
- Skip the **iOS reveal-settle `finishBootstrapInitialScrollWithoutScroll`** shortcut for horizontal RTL for the same reason — a logical-vs-native offset comparison is meaningless under RTL inversion, so RTL always takes the dispatch path.

All four are scoped to horizontal RTL (`isHorizontalRTL` / `isHorizontalRTLProps` / `horizontal` guards) — non-RTL and vertical paths are unaffected. No extra frames/retries are added for index 0; it simply uses the same bootstrap → dispatch → convert path every other index already uses.

## Verification

- `bun run tsc:src` ✅, `bunx biome check` ✅, `bun test` → 1369 pass / 1 fail (the pre-existing old-arch bootstrap process-isolation test, fails on `main` unchanged).
- **Near-the-end mirror:** reproduced + confirmed fixed in a minimal Expo repro (`@legendapp/list@3.0.6`, RN 0.85.3, Android) — without the fix the list settles on the mirror index (deterministic, 5/5 cold starts); with the fix it settles on the requested item.
- **Index-0 blank (Android):** reproduced + confirmed fixed in a real horizontal-RTL app (Android, `mushaf-book-legend-list`) — `initialScrollIndex={0}` cold-mount rendered blank before, renders the first item after; verified via a patch of this change on `@legendapp/list` 3.2.0 and 3.3.2 (the bug function is byte-identical across those versions).
- **Index-0 blank (iOS reveal-settle):** reproduced + confirmed fixed on a physical iPad (iOS, same app) — with fixes 1–3 only, the mount still finished via the reveal-settle branch and rendered blank; with fix 4, instrumentation shows the bootstrap dispatching the converted native offset (`scrollTo → maxOffset`) and the first item renders.

Repro: https://github.com/Mohamed-kassim/legend-list-rtl-repro
