### PR TITLE
fix(rtl): horizontal list renders blank in a native-RTL app

### DIFF
--- a/src/components/ListComponent.tsx
+++ b/src/components/ListComponent.tsx
@@ -30,6 +30,7 @@ import { useArr$, useStateContext } from "@/state/state";
 import { type GetRenderedItem, type LegendListPropsBase, typedMemo } from "@/types.internal";
 import { IS_DEV } from "@/utils/devEnvironment";
 import { getComponent } from "@/utils/getComponent";
+import { isHorizontalRTL } from "@/utils/rtl";
 
 interface ListComponentProps<ItemT>
     extends Omit<
@@ -200,7 +201,18 @@ export const ListComponent = typedMemo(function ListComponent<ItemT>({
             onScroll={onScroll}
             ref={refScrollView as any}
             ScrollComponent={snapToIndices ? ScrollComponent : (undefined as any)}
-            style={autoOtherAxisStyle ? [autoOtherAxisStyle, style] : style}
+            // RTL is emulated in logical (LTR) coordinates with item positions mirrored
+            // in JS, so the scroll container must stay LTR. On web that's done per-item
+            // (Container.tsx); on native the container itself also flips under
+            // I18nManager.isRTL, and the double flip renders the list blank — so
+            // neutralize the native flip here too. See #477. Keep this array flat: the
+            // web scroll view flattens it shallowly, so a nested array would drop the
+            // measured cross-axis size.
+            style={[
+                isHorizontalRTL(ctx.state) && Platform.OS !== "web" ? { direction: "ltr" } : null,
+                autoOtherAxisStyle,
+                style,
+            ]}
         >
             <ScrollAdjust />
             {ListHeaderComponent && (


### PR DESCRIPTION
Horizontal lists show up **completely blank** in a native‑RTL app (`I18nManager.isRTL === true`, e.g. an Arabic or Urdu locale). Nothing paints, though `onViewableItemsChanged` keeps firing, so the items are there, just positioned offscreen. LTR apps (and LTR apps using the `rtl` prop) work fine.

**Why it happens:** the library does its own RTL, it keeps logical (LTR) offsets and mirrors item positions in JS. That only works if the scroll container itself stays LTR, which is why it already forces `direction: "ltr"` **on web** (in `Container.tsx`). On native that step is missing, so when the app is RTL the `ScrollView` flips *as well*,  the JS mirror and the native flip stack on top of each other and the rendered items end up offscreen.

**The fix:** just do on native what web already does — keep the scroll container LTR for horizontal RTL lists, so the JS mirror is the only flip:

```diff
- style={autoOtherAxisStyle ? [autoOtherAxisStyle, style] : style}
+ style={[
+     isHorizontalRTL(ctx.state) && Platform.OS !== "web" ? { direction: "ltr" } : null,
+     autoOtherAxisStyle ? [autoOtherAxisStyle, style] : style,
+ ]}
```

LTR and vertical lists are untouched.

**Repro:** https://github.com/Mohamed-kassim/legend-list-rtl-repro/tree/case/native-rtl-blank — forces native RTL and renders a horizontal `rtl` list of 604 pages → blank on Android (happens in every config, even at `initialScrollIndex=0`).

**Tested** on a real Android device and that repro on 3.2.0: blank before, renders after; `scrollToIndex` and paging both work.

One heads‑up: `direction: "ltr"` inherits down to item content. In practice that's fine, items are positioned with physical `left`, and RN `Text` auto‑detects its own direction , but I'm happy to also reset `direction: "rtl"` on the content wrapper if you'd rather keep it fully contained.

Fixes #477
