### PR TITLE
fix: end-aligned scroll completion — pendingTotalSize deadlock, watchdog bounding, moving-target slack, animated retries

### DIFF
--- a/__tests__/__mocks__/createEndAlignedScrollContext.ts
+++ b/__tests__/__mocks__/createEndAlignedScrollContext.ts
@@ -1,0 +1,49 @@
+import { createMockContext } from "./createMockContext";
+
+export type RecordedScrollTo = { animated: boolean; x: number; y: number };
+
+// 1000 items of ~401px with the last item at 394259 sized 441, so the content
+// ends at 394700. With a 701px viewport the end-aligned target is 393999.
+export function createEndAlignedScrollContext(
+    scroll: number,
+    scrollToCalls: RecordedScrollTo[],
+    stateOverrides: Record<string, any> = {},
+) {
+    const data = Array.from({ length: 1000 }, (_, index) => ({ id: index }));
+    const positions = Array.from({ length: 1000 }, (_, index) => index * 401);
+    positions[999] = 394259;
+
+    return createMockContext(
+        { totalSize: 394700 },
+        {
+            didContainersLayout: true,
+            hasScrolled: true,
+            positions,
+            props: {
+                data,
+                estimatedItemSize: 401,
+            } as any,
+            refScroller: {
+                current: {
+                    scrollTo: (params: RecordedScrollTo) => scrollToCalls.push(params),
+                },
+            } as any,
+            scroll,
+            scrollLength: 701,
+            scrollPending: scroll,
+            sizesKnown: new Map([["item_999", 441]]),
+            ...stateOverrides,
+        },
+    );
+}
+
+export function createEndAlignedScrollTarget(animated: boolean) {
+    return {
+        animated,
+        index: 999,
+        offset: 397479,
+        targetOffset: 397179,
+        viewOffset: 0,
+        viewPosition: 1,
+    } as any;
+}

--- a/__tests__/core/checkFinishedScroll.test.ts
+++ b/__tests__/core/checkFinishedScroll.test.ts
@@ -3,6 +3,11 @@ import "../setup";
 
 import { checkFinishedScroll, checkFinishedScrollFallback } from "../../src/core/checkFinishedScroll";
 import { Platform } from "../../src/platform/Platform";
+import {
+    createEndAlignedScrollContext,
+    createEndAlignedScrollTarget,
+    type RecordedScrollTo,
+} from "../__mocks__/createEndAlignedScrollContext";
 import { createMockContext } from "../__mocks__/createMockContext";
 
 describe("checkFinishedScrollFallback", () => {
@@ -142,40 +147,10 @@ describe("checkFinishedScrollFallback", () => {
 
     it("retries an unresolved iOS scroll to end at the current measured end target", () => {
         Platform.OS = "ios";
-        const scrollToCalls: Array<{ animated: boolean; x: number; y: number }> = [];
-        const data = Array.from({ length: 1000 }, (_, index) => ({ id: index }));
-        const positions = Array.from({ length: 1000 }, (_, index) => index * 401);
-        positions[999] = 394259;
-
-        const ctx = createMockContext(
-            { totalSize: 394700 },
-            {
-                didContainersLayout: true,
-                hasScrolled: true,
-                positions,
-                props: {
-                    data,
-                    estimatedItemSize: 401,
-                } as any,
-                refScroller: {
-                    current: {
-                        scrollTo: (params: { animated: boolean; x: number; y: number }) => scrollToCalls.push(params),
-                    },
-                } as any,
-                scroll: 393753.3333333333,
-                scrollingTo: {
-                    animated: true,
-                    index: 999,
-                    offset: 397479,
-                    targetOffset: 397179,
-                    viewOffset: 0,
-                    viewPosition: 1,
-                } as any,
-                scrollLength: 701,
-                scrollPending: 393753.3333333333,
-                sizesKnown: new Map([["item_999", 441]]),
-            },
-        );
+        const scrollToCalls: RecordedScrollTo[] = [];
+        const ctx = createEndAlignedScrollContext(393753.3333333333, scrollToCalls, {
+            scrollingTo: createEndAlignedScrollTarget(true),
+        });
 
         checkFinishedScrollFallback(ctx);
 
@@ -191,40 +166,10 @@ describe("checkFinishedScrollFallback", () => {
 
     it("retries an unresolved unanimated iOS scroll to end without animation", () => {
         Platform.OS = "ios";
-        const scrollToCalls: Array<{ animated: boolean; x: number; y: number }> = [];
-        const data = Array.from({ length: 1000 }, (_, index) => ({ id: index }));
-        const positions = Array.from({ length: 1000 }, (_, index) => index * 401);
-        positions[999] = 394259;
-
-        const ctx = createMockContext(
-            { totalSize: 394700 },
-            {
-                didContainersLayout: true,
-                hasScrolled: true,
-                positions,
-                props: {
-                    data,
-                    estimatedItemSize: 401,
-                } as any,
-                refScroller: {
-                    current: {
-                        scrollTo: (params: { animated: boolean; x: number; y: number }) => scrollToCalls.push(params),
-                    },
-                } as any,
-                scroll: 393753.3333333333,
-                scrollingTo: {
-                    animated: false,
-                    index: 999,
-                    offset: 397479,
-                    targetOffset: 397179,
-                    viewOffset: 0,
-                    viewPosition: 1,
-                } as any,
-                scrollLength: 701,
-                scrollPending: 393753.3333333333,
-                sizesKnown: new Map([["item_999", 441]]),
-            },
-        );
+        const scrollToCalls: RecordedScrollTo[] = [];
+        const ctx = createEndAlignedScrollContext(393753.3333333333, scrollToCalls, {
+            scrollingTo: createEndAlignedScrollTarget(false),
+        });
 
         checkFinishedScrollFallback(ctx);
 

--- a/__tests__/core/checkFinishedScroll.test.ts
+++ b/__tests__/core/checkFinishedScroll.test.ts
@@ -180,13 +180,56 @@ describe("checkFinishedScrollFallback", () => {
         checkFinishedScrollFallback(ctx);
 
         flushTimers(1);
-        expect(scrollToCalls).toEqual([{ animated: false, x: 0, y: 393999 }]);
+        expect(scrollToCalls).toEqual([{ animated: true, x: 0, y: 393999 }]);
         expect(ctx.state.scrollingTo).toBeDefined();
 
         ctx.state.scroll = 393999;
         ctx.state.scrollPending = 393999;
         flushTimers(1);
         expect(ctx.state.scrollingTo).toBeUndefined();
+    });
+
+    it("retries an unresolved unanimated iOS scroll to end without animation", () => {
+        Platform.OS = "ios";
+        const scrollToCalls: Array<{ animated: boolean; x: number; y: number }> = [];
+        const data = Array.from({ length: 1000 }, (_, index) => ({ id: index }));
+        const positions = Array.from({ length: 1000 }, (_, index) => index * 401);
+        positions[999] = 394259;
+
+        const ctx = createMockContext(
+            { totalSize: 394700 },
+            {
+                didContainersLayout: true,
+                hasScrolled: true,
+                positions,
+                props: {
+                    data,
+                    estimatedItemSize: 401,
+                } as any,
+                refScroller: {
+                    current: {
+                        scrollTo: (params: { animated: boolean; x: number; y: number }) => scrollToCalls.push(params),
+                    },
+                } as any,
+                scroll: 393753.3333333333,
+                scrollingTo: {
+                    animated: false,
+                    index: 999,
+                    offset: 397479,
+                    targetOffset: 397179,
+                    viewOffset: 0,
+                    viewPosition: 1,
+                } as any,
+                scrollLength: 701,
+                scrollPending: 393753.3333333333,
+                sizesKnown: new Map([["item_999", 441]]),
+            },
+        );
+
+        checkFinishedScrollFallback(ctx);
+
+        flushTimers(1);
+        expect(scrollToCalls).toEqual([{ animated: false, x: 0, y: 393999 }]);
     });
 
     it("reissues native scrollTo while an initial non-zero target is still pending", () => {

--- a/__tests__/core/endAlignedScrollTarget.test.ts
+++ b/__tests__/core/endAlignedScrollTarget.test.ts
@@ -1,0 +1,109 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import "../setup";
+
+import { maybeCorrectEndAlignedScrollAfterCommit } from "../../src/core/endAlignedScrollTarget";
+import { createMockContext } from "../__mocks__/createMockContext";
+
+describe("maybeCorrectEndAlignedScrollAfterCommit", () => {
+    let originalRequestAnimationFrame: typeof globalThis.requestAnimationFrame;
+
+    beforeEach(() => {
+        originalRequestAnimationFrame = globalThis.requestAnimationFrame;
+        globalThis.requestAnimationFrame = ((callback: FrameRequestCallback) => {
+            callback(0);
+            return 1;
+        }) as typeof globalThis.requestAnimationFrame;
+    });
+
+    afterEach(() => {
+        globalThis.requestAnimationFrame = originalRequestAnimationFrame;
+    });
+
+    // End content at 394259 + 441 = 394700, scrollLength 701 → end target 393999.
+    const createEndAlignedContext = (
+        scroll: number,
+        scrollToCalls: Array<{ animated: boolean; x: number; y: number }>,
+    ) => {
+        const data = Array.from({ length: 1000 }, (_, index) => ({ id: index }));
+        const positions = Array.from({ length: 1000 }, (_, index) => index * 401);
+        positions[999] = 394259;
+
+        return createMockContext(
+            { totalSize: 394700 },
+            {
+                didContainersLayout: true,
+                hasScrolled: true,
+                positions,
+                props: {
+                    data,
+                    estimatedItemSize: 401,
+                } as any,
+                refScroller: {
+                    current: {
+                        scrollTo: (params: { animated: boolean; x: number; y: number }) => scrollToCalls.push(params),
+                    },
+                } as any,
+                scroll,
+                scrollLength: 701,
+                scrollPending: scroll,
+                sizesKnown: new Map([["item_999", 441]]),
+            },
+        );
+    };
+
+    const endAlignedTarget = (animated: boolean) =>
+        ({
+            animated,
+            index: 999,
+            offset: 397479,
+            targetOffset: 397179,
+            viewOffset: 0,
+            viewPosition: 1,
+        }) as any;
+
+    it("glides a large remainder when the finished session was animated", () => {
+        const scrollToCalls: Array<{ animated: boolean; x: number; y: number }> = [];
+        const ctx = createEndAlignedContext(393753, scrollToCalls);
+
+        maybeCorrectEndAlignedScrollAfterCommit(ctx, endAlignedTarget(true));
+
+        expect(scrollToCalls).toEqual([{ animated: true, x: 0, y: 393999 }]);
+    });
+
+    it("snaps a small residue instantly even when the finished session was animated", () => {
+        const scrollToCalls: Array<{ animated: boolean; x: number; y: number }> = [];
+        const ctx = createEndAlignedContext(393969, scrollToCalls);
+
+        maybeCorrectEndAlignedScrollAfterCommit(ctx, endAlignedTarget(true));
+
+        expect(scrollToCalls).toEqual([{ animated: false, x: 0, y: 393999 }]);
+    });
+
+    it("corrects unanimated sessions without animation", () => {
+        const scrollToCalls: Array<{ animated: boolean; x: number; y: number }> = [];
+        const ctx = createEndAlignedContext(393753, scrollToCalls);
+
+        maybeCorrectEndAlignedScrollAfterCommit(ctx, endAlignedTarget(false));
+
+        expect(scrollToCalls).toEqual([{ animated: false, x: 0, y: 393999 }]);
+    });
+
+    it("does not dispatch when already at the corrected target", () => {
+        const scrollToCalls: Array<{ animated: boolean; x: number; y: number }> = [];
+        const ctx = createEndAlignedContext(393999, scrollToCalls);
+
+        maybeCorrectEndAlignedScrollAfterCommit(ctx, endAlignedTarget(true));
+
+        expect(scrollToCalls).toEqual([]);
+    });
+
+    it("bails when a new scroll session started before the correction frame", () => {
+        const scrollToCalls: Array<{ animated: boolean; x: number; y: number }> = [];
+        const ctx = createEndAlignedContext(393753, scrollToCalls);
+        ctx.state.scrollingTo = endAlignedTarget(true);
+
+        maybeCorrectEndAlignedScrollAfterCommit(ctx, endAlignedTarget(true));
+
+        expect(scrollToCalls).toEqual([]);
+    });
+});

--- a/__tests__/core/endAlignedScrollTarget.test.ts
+++ b/__tests__/core/endAlignedScrollTarget.test.ts
@@ -2,7 +2,11 @@ import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import "../setup";
 
 import { maybeCorrectEndAlignedScrollAfterCommit } from "../../src/core/endAlignedScrollTarget";
-import { createMockContext } from "../__mocks__/createMockContext";
+import {
+    createEndAlignedScrollContext,
+    createEndAlignedScrollTarget,
+    type RecordedScrollTo,
+} from "../__mocks__/createEndAlignedScrollContext";
 
 describe("maybeCorrectEndAlignedScrollAfterCommit", () => {
     let originalRequestAnimationFrame: typeof globalThis.requestAnimationFrame;
@@ -19,90 +23,48 @@ describe("maybeCorrectEndAlignedScrollAfterCommit", () => {
         globalThis.requestAnimationFrame = originalRequestAnimationFrame;
     });
 
-    // End content at 394259 + 441 = 394700, scrollLength 701 → end target 393999.
-    const createEndAlignedContext = (
-        scroll: number,
-        scrollToCalls: Array<{ animated: boolean; x: number; y: number }>,
-    ) => {
-        const data = Array.from({ length: 1000 }, (_, index) => ({ id: index }));
-        const positions = Array.from({ length: 1000 }, (_, index) => index * 401);
-        positions[999] = 394259;
-
-        return createMockContext(
-            { totalSize: 394700 },
-            {
-                didContainersLayout: true,
-                hasScrolled: true,
-                positions,
-                props: {
-                    data,
-                    estimatedItemSize: 401,
-                } as any,
-                refScroller: {
-                    current: {
-                        scrollTo: (params: { animated: boolean; x: number; y: number }) => scrollToCalls.push(params),
-                    },
-                } as any,
-                scroll,
-                scrollLength: 701,
-                scrollPending: scroll,
-                sizesKnown: new Map([["item_999", 441]]),
-            },
-        );
-    };
-
-    const endAlignedTarget = (animated: boolean) =>
-        ({
-            animated,
-            index: 999,
-            offset: 397479,
-            targetOffset: 397179,
-            viewOffset: 0,
-            viewPosition: 1,
-        }) as any;
-
     it("glides a large remainder when the finished session was animated", () => {
-        const scrollToCalls: Array<{ animated: boolean; x: number; y: number }> = [];
-        const ctx = createEndAlignedContext(393753, scrollToCalls);
+        const scrollToCalls: RecordedScrollTo[] = [];
+        const ctx = createEndAlignedScrollContext(393753, scrollToCalls);
 
-        maybeCorrectEndAlignedScrollAfterCommit(ctx, endAlignedTarget(true));
+        maybeCorrectEndAlignedScrollAfterCommit(ctx, createEndAlignedScrollTarget(true));
 
         expect(scrollToCalls).toEqual([{ animated: true, x: 0, y: 393999 }]);
     });
 
     it("snaps a small residue instantly even when the finished session was animated", () => {
-        const scrollToCalls: Array<{ animated: boolean; x: number; y: number }> = [];
-        const ctx = createEndAlignedContext(393969, scrollToCalls);
+        const scrollToCalls: RecordedScrollTo[] = [];
+        const ctx = createEndAlignedScrollContext(393969, scrollToCalls);
 
-        maybeCorrectEndAlignedScrollAfterCommit(ctx, endAlignedTarget(true));
+        maybeCorrectEndAlignedScrollAfterCommit(ctx, createEndAlignedScrollTarget(true));
 
         expect(scrollToCalls).toEqual([{ animated: false, x: 0, y: 393999 }]);
     });
 
     it("corrects unanimated sessions without animation", () => {
-        const scrollToCalls: Array<{ animated: boolean; x: number; y: number }> = [];
-        const ctx = createEndAlignedContext(393753, scrollToCalls);
+        const scrollToCalls: RecordedScrollTo[] = [];
+        const ctx = createEndAlignedScrollContext(393753, scrollToCalls);
 
-        maybeCorrectEndAlignedScrollAfterCommit(ctx, endAlignedTarget(false));
+        maybeCorrectEndAlignedScrollAfterCommit(ctx, createEndAlignedScrollTarget(false));
 
         expect(scrollToCalls).toEqual([{ animated: false, x: 0, y: 393999 }]);
     });
 
     it("does not dispatch when already at the corrected target", () => {
-        const scrollToCalls: Array<{ animated: boolean; x: number; y: number }> = [];
-        const ctx = createEndAlignedContext(393999, scrollToCalls);
+        const scrollToCalls: RecordedScrollTo[] = [];
+        const ctx = createEndAlignedScrollContext(393999, scrollToCalls);
 
-        maybeCorrectEndAlignedScrollAfterCommit(ctx, endAlignedTarget(true));
+        maybeCorrectEndAlignedScrollAfterCommit(ctx, createEndAlignedScrollTarget(true));
 
         expect(scrollToCalls).toEqual([]);
     });
 
     it("bails when a new scroll session started before the correction frame", () => {
-        const scrollToCalls: Array<{ animated: boolean; x: number; y: number }> = [];
-        const ctx = createEndAlignedContext(393753, scrollToCalls);
-        ctx.state.scrollingTo = endAlignedTarget(true);
+        const scrollToCalls: RecordedScrollTo[] = [];
+        const ctx = createEndAlignedScrollContext(393753, scrollToCalls);
+        ctx.state.scrollingTo = createEndAlignedScrollTarget(true);
 
-        maybeCorrectEndAlignedScrollAfterCommit(ctx, endAlignedTarget(true));
+        maybeCorrectEndAlignedScrollAfterCommit(ctx, createEndAlignedScrollTarget(true));
 
         expect(scrollToCalls).toEqual([]);
     });

--- a/bun.lock
+++ b/bun.lock
@@ -29,7 +29,13 @@
       },
       "peerDependencies": {
         "react": "*",
+        "react-dom": "*",
+        "react-native": "*",
       },
+      "optionalPeers": [
+        "react-dom",
+        "react-native",
+      ],
     },
   },
   "packages": {

--- a/bun.lock
+++ b/bun.lock
@@ -29,13 +29,7 @@
       },
       "peerDependencies": {
         "react": "*",
-        "react-dom": "*",
-        "react-native": "*",
       },
-      "optionalPeers": [
-        "react-dom",
-        "react-native",
-      ],
     },
   },
   "packages": {

--- a/src/core/checkFinishedScroll.ts
+++ b/src/core/checkFinishedScroll.ts
@@ -242,7 +242,11 @@ export function checkFinishedScrollFallback(ctx: StateContext) {
                     });
                     scheduleFallbackCheck(SILENT_INITIAL_SCROLL_RETRY_DELAY_MS);
                 } else if (shouldRetryUnalignedEndScroll) {
-                    scrollToFallbackOffset(ctx, completionState.clampedTargetOffset);
+                    // An animated dispatch gets clamped short when the end target sits
+                    // beyond the natively committed range (uncommitted total size or end
+                    // inset). Retry with the session's animation so the remaining distance
+                    // glides instead of teleporting.
+                    scrollToFallbackOffset(ctx, completionState.clampedTargetOffset, !!isStillScrollingTo.animated);
                     scheduleFallbackCheck(100);
                 } else if (
                     shouldFinishZeroTarget ||

--- a/src/core/checkFinishedScroll.ts
+++ b/src/core/checkFinishedScroll.ts
@@ -13,6 +13,7 @@ import type { StateContext } from "@/state/state";
 type ActiveScrollTarget = NonNullable<StateContext["state"]["scrollingTo"]>;
 const INITIAL_SCROLL_MAX_FALLBACK_CHECKS = 20;
 const MAX_FALLBACK_CHECKS_PER_SESSION = 40;
+const END_ALIGNED_COMPLETION_EPSILON = 30;
 const INITIAL_SCROLL_COMPLETION_TARGET_EPSILON = 1;
 const INITIAL_SCROLL_ZERO_TARGET_EPSILON = 1;
 const SILENT_INITIAL_SCROLL_RETRY_DELAY_MS = 16;
@@ -111,10 +112,17 @@ function getResolvedScrollCompletionState(ctx: StateContext, scrollingTo: Active
     const adjustedTargetOffset = clampedTargetOffset + adjust;
     const diff2 = Math.abs(scroll - adjustedTargetOffset);
     const canUseAdjustedCompletion = !scrollingTo.animated || Platform.OS === "ios";
+    // End-aligned targets move while content grows (and pendingTotalSize keeps
+    // them ~one commit ahead of the reachable native range). Chasing them to
+    // sub-pixel precision causes visible retry jumps; finish within slack
+    // instead and let the post-commit end correction snap the exact position.
+    const completionEpsilon = isEndAlignedLastItemTarget(ctx, scrollingTo) ? END_ALIGNED_COMPLETION_EPSILON : 1;
 
     return {
         clampedTargetOffset,
-        isAtResolvedTarget: Math.abs(scroll - maxOffset) < 1 && (diff1 < 1 || (canUseAdjustedCompletion && diff2 < 1)),
+        isAtResolvedTarget:
+            Math.abs(scroll - maxOffset) < completionEpsilon &&
+            (diff1 < completionEpsilon || (canUseAdjustedCompletion && diff2 < completionEpsilon)),
     };
 }
 

--- a/src/core/checkFinishedScroll.ts
+++ b/src/core/checkFinishedScroll.ts
@@ -12,6 +12,7 @@ import type { StateContext } from "@/state/state";
 
 type ActiveScrollTarget = NonNullable<StateContext["state"]["scrollingTo"]>;
 const INITIAL_SCROLL_MAX_FALLBACK_CHECKS = 20;
+const MAX_FALLBACK_CHECKS_PER_SESSION = 40;
 const INITIAL_SCROLL_COMPLETION_TARGET_EPSILON = 1;
 const INITIAL_SCROLL_ZERO_TARGET_EPSILON = 1;
 const SILENT_INITIAL_SCROLL_RETRY_DELAY_MS = 16;
@@ -141,6 +142,13 @@ function checkFinishedScrollFrame(ctx: StateContext) {
 // to make sure it does eventually get cleared, just waiting for scroll to end
 export function checkFinishedScrollFallback(ctx: StateContext) {
     const state = ctx.state;
+    // Re-arming replaces the pending watchdog instead of orphaning it: each
+    // orphaned closure kept its own retry loop alive, multiplying timers and
+    // native scroll dispatches while a scroll session stayed unresolved.
+    if (state.timeoutCheckFinishedScrollFallback) {
+        clearTimeout(state.timeoutCheckFinishedScrollFallback);
+        state.timeoutCheckFinishedScrollFallback = undefined;
+    }
     const scrollingTo = state.scrollingTo;
     const shouldFinishInitialZeroTarget = shouldFinishInitialZeroTargetScroll(ctx);
     const silentInitialDispatch = isSilentInitialDispatch(state, scrollingTo);
@@ -169,6 +177,18 @@ export function checkFinishedScrollFallback(ctx: StateContext) {
             const isStillScrollingTo = state.scrollingTo;
             if (isStillScrollingTo) {
                 numChecks++;
+                // Hard bound per scroll session, stored on state so it survives
+                // watchdog re-arms: without it, continuous re-dispatches reset the
+                // closure-local numChecks and the finish escape never fires.
+                if (state.fallbackScrollSession !== isStillScrollingTo) {
+                    state.fallbackScrollSession = isStillScrollingTo;
+                    state.fallbackScrollSessionChecks = 0;
+                }
+                state.fallbackScrollSessionChecks = (state.fallbackScrollSessionChecks ?? 0) + 1;
+                if (state.fallbackScrollSessionChecks > MAX_FALLBACK_CHECKS_PER_SESSION) {
+                    finishScrollTo(ctx);
+                    return;
+                }
                 const isNativeInitialPending = isNativeInitialNonZeroTarget(state) && !state.hasScrolled;
                 const maxChecks = silentInitialDispatch
                     ? 5

--- a/src/core/checkFinishedScroll.ts
+++ b/src/core/checkFinishedScroll.ts
@@ -1,6 +1,9 @@
-import { calculateOffsetForIndex } from "@/core/calculateOffsetForIndex";
-import { calculateOffsetWithOffsetPosition } from "@/core/calculateOffsetWithOffsetPosition";
 import { clampScrollOffset } from "@/core/clampScrollOffset";
+import {
+    getCurrentTargetOffset,
+    isEndAlignedLastItemTarget,
+    scrollToFallbackOffset,
+} from "@/core/endAlignedScrollTarget";
 import { finishScrollTo } from "@/core/finishScrollTo";
 import { initialScrollCompletion, initialScrollWatchdog } from "@/core/initialScrollSession";
 import { Platform } from "@/platform/Platform";
@@ -97,22 +100,6 @@ function shouldFinishInitialZeroTargetScroll(ctx: StateContext) {
     );
 }
 
-function isEndAlignedLastItemTarget(ctx: StateContext, scrollingTo: ActiveScrollTarget) {
-    return scrollingTo.index === ctx.state.props.data.length - 1 && scrollingTo.viewPosition === 1;
-}
-
-function getCurrentTargetOffset(ctx: StateContext, scrollingTo: ActiveScrollTarget) {
-    const index = scrollingTo.index;
-    const shouldRecomputeEndTarget = isEndAlignedLastItemTarget(ctx, scrollingTo);
-    const requestedTargetOffset =
-        shouldRecomputeEndTarget && index !== undefined
-            ? calculateOffsetWithOffsetPosition(ctx, calculateOffsetForIndex(ctx, index), scrollingTo)
-            : (scrollingTo.targetOffset ??
-              clampScrollOffset(ctx, scrollingTo.offset - (scrollingTo.viewOffset || 0), scrollingTo));
-
-    return clampScrollOffset(ctx, requestedTargetOffset, scrollingTo);
-}
-
 function getResolvedScrollCompletionState(ctx: StateContext, scrollingTo: ActiveScrollTarget) {
     const { state } = ctx;
     const scroll = state.scrollPending;
@@ -148,14 +135,6 @@ function checkFinishedScrollFrame(ctx: StateContext) {
     ) {
         finishScrollTo(ctx);
     }
-}
-
-function scrollToFallbackOffset(ctx: StateContext, offset: number) {
-    ctx.state.refScroller.current?.scrollTo({
-        animated: false,
-        x: ctx.state.props.horizontal ? offset : 0,
-        y: ctx.state.props.horizontal ? 0 : offset,
-    });
 }
 
 // In case checkFinishedScroll does not work correctly, set a maximum timeout

--- a/src/core/checkFinishedScroll.ts
+++ b/src/core/checkFinishedScroll.ts
@@ -1,7 +1,9 @@
 import { clampScrollOffset } from "@/core/clampScrollOffset";
 import {
+    END_ALIGNED_COMPLETION_EPSILON,
     getCurrentTargetOffset,
     isEndAlignedLastItemTarget,
+    redispatchEndAlignedTarget,
     scrollToFallbackOffset,
 } from "@/core/endAlignedScrollTarget";
 import { finishScrollTo } from "@/core/finishScrollTo";
@@ -13,7 +15,6 @@ import type { StateContext } from "@/state/state";
 type ActiveScrollTarget = NonNullable<StateContext["state"]["scrollingTo"]>;
 const INITIAL_SCROLL_MAX_FALLBACK_CHECKS = 20;
 const MAX_FALLBACK_CHECKS_PER_SESSION = 40;
-const END_ALIGNED_COMPLETION_EPSILON = 30;
 const INITIAL_SCROLL_COMPLETION_TARGET_EPSILON = 1;
 const INITIAL_SCROLL_ZERO_TARGET_EPSILON = 1;
 const SILENT_INITIAL_SCROLL_RETRY_DELAY_MS = 16;
@@ -238,11 +239,7 @@ export function checkFinishedScrollFallback(ctx: StateContext) {
                     });
                     scheduleFallbackCheck(SILENT_INITIAL_SCROLL_RETRY_DELAY_MS);
                 } else if (shouldRetryUnalignedEndScroll) {
-                    // An animated dispatch gets clamped short when the end target sits
-                    // beyond the natively committed range (uncommitted total size or end
-                    // inset). Retry with the session's animation so the remaining distance
-                    // glides instead of teleporting.
-                    scrollToFallbackOffset(ctx, completionState.clampedTargetOffset, !!isStillScrollingTo.animated);
+                    redispatchEndAlignedTarget(ctx, isStillScrollingTo, completionState.clampedTargetOffset);
                     scheduleFallbackCheck(100);
                 } else if (
                     shouldFinishZeroTarget ||

--- a/src/core/checkFinishedScroll.ts
+++ b/src/core/checkFinishedScroll.ts
@@ -185,15 +185,11 @@ export function checkFinishedScrollFallback(ctx: StateContext) {
             const isStillScrollingTo = state.scrollingTo;
             if (isStillScrollingTo) {
                 numChecks++;
-                // Hard bound per scroll session, stored on state so it survives
-                // watchdog re-arms: without it, continuous re-dispatches reset the
-                // closure-local numChecks and the finish escape never fires.
-                if (state.fallbackScrollSession !== isStillScrollingTo) {
-                    state.fallbackScrollSession = isStillScrollingTo;
-                    state.fallbackScrollSessionChecks = 0;
-                }
-                state.fallbackScrollSessionChecks = (state.fallbackScrollSessionChecks ?? 0) + 1;
-                if (state.fallbackScrollSessionChecks > MAX_FALLBACK_CHECKS_PER_SESSION) {
+                // Hard bound carried on the session itself so it survives watchdog
+                // re-arms: continuous re-dispatches reset the closure-local numChecks,
+                // and without a persistent count the finish escape never fires.
+                isStillScrollingTo.fallbackChecks = (isStillScrollingTo.fallbackChecks ?? 0) + 1;
+                if (isStillScrollingTo.fallbackChecks > MAX_FALLBACK_CHECKS_PER_SESSION) {
                     finishScrollTo(ctx);
                     return;
                 }

--- a/src/core/endAlignedScrollTarget.ts
+++ b/src/core/endAlignedScrollTarget.ts
@@ -5,7 +5,11 @@ import type { StateContext } from "@/state/state";
 
 type ActiveScrollTarget = NonNullable<StateContext["state"]["scrollingTo"]>;
 
-const ANIMATED_CORRECTION_MIN_DISTANCE = 40;
+// End-aligned targets move while content grows (pendingTotalSize keeps them
+// ~one commit ahead of the reachable native range), so completion and
+// re-dispatch share this slack: sessions finish within it, and re-dispatched
+// remainders beyond it glide while smaller ones snap imperceptibly.
+export const END_ALIGNED_COMPLETION_EPSILON = 30;
 
 export function isEndAlignedLastItemTarget(ctx: StateContext, scrollingTo: ActiveScrollTarget) {
     return scrollingTo.index === ctx.state.props.data.length - 1 && scrollingTo.viewPosition === 1;
@@ -23,7 +27,21 @@ export function getCurrentTargetOffset(ctx: StateContext, scrollingTo: ActiveScr
     return clampScrollOffset(ctx, requestedTargetOffset, scrollingTo);
 }
 
-export function scrollToFallbackOffset(ctx: StateContext, offset: number, animated = false) {
+export function scrollToFallbackOffset(ctx: StateContext, offset: number) {
+    dispatchScrollTo(ctx, offset, false);
+}
+
+// Re-dispatch an end-aligned session at its recomputed target. An animated
+// dispatch gets clamped short when the target sits beyond the natively
+// committed range (uncommitted total size or end inset), so an animated
+// session with a remainder beyond the completion slack glides the rest of
+// the way instead of teleporting; smaller remainders snap imperceptibly.
+export function redispatchEndAlignedTarget(ctx: StateContext, scrollingTo: ActiveScrollTarget, target: number) {
+    const animated = !!scrollingTo.animated && target - ctx.state.scroll > END_ALIGNED_COMPLETION_EPSILON;
+    dispatchScrollTo(ctx, target, animated);
+}
+
+function dispatchScrollTo(ctx: StateContext, offset: number, animated: boolean) {
     ctx.state.refScroller.current?.scrollTo({
         animated,
         x: ctx.state.props.horizontal ? offset : 0,
@@ -37,10 +55,7 @@ export function scrollToFallbackOffset(ctx: StateContext, offset: number, animat
 // beyond the reachable range and retries could not move past it. Once the
 // committed size lands natively (two frames), re-dispatch a single correction
 // toward the end. One-shot and end-directed, so it cannot loop or fight the
-// user. A large remainder on an animated session means the original dispatch
-// was clamped short (uncommitted size or end inset), so the correction glides
-// instead of teleporting; small residue snaps instantly to keep the settle
-// imperceptible.
+// user.
 export function maybeCorrectEndAlignedScrollAfterCommit(ctx: StateContext, scrollingTo: ActiveScrollTarget) {
     const state = ctx.state;
     if (!isEndAlignedLastItemTarget(ctx, scrollingTo)) {
@@ -54,9 +69,7 @@ export function maybeCorrectEndAlignedScrollAfterCommit(ctx: StateContext, scrol
             }
             const correctedTarget = getCurrentTargetOffset(ctx, scrollingTo);
             if (correctedTarget > state.scroll + 1) {
-                const animated =
-                    !!scrollingTo.animated && correctedTarget - state.scroll > ANIMATED_CORRECTION_MIN_DISTANCE;
-                scrollToFallbackOffset(ctx, correctedTarget, animated);
+                redispatchEndAlignedTarget(ctx, scrollingTo, correctedTarget);
             }
         });
     });

--- a/src/core/endAlignedScrollTarget.ts
+++ b/src/core/endAlignedScrollTarget.ts
@@ -1,0 +1,30 @@
+import { calculateOffsetForIndex } from "@/core/calculateOffsetForIndex";
+import { calculateOffsetWithOffsetPosition } from "@/core/calculateOffsetWithOffsetPosition";
+import { clampScrollOffset } from "@/core/clampScrollOffset";
+import type { StateContext } from "@/state/state";
+
+type ActiveScrollTarget = NonNullable<StateContext["state"]["scrollingTo"]>;
+
+export function isEndAlignedLastItemTarget(ctx: StateContext, scrollingTo: ActiveScrollTarget) {
+    return scrollingTo.index === ctx.state.props.data.length - 1 && scrollingTo.viewPosition === 1;
+}
+
+export function getCurrentTargetOffset(ctx: StateContext, scrollingTo: ActiveScrollTarget) {
+    const index = scrollingTo.index;
+    const shouldRecomputeEndTarget = isEndAlignedLastItemTarget(ctx, scrollingTo);
+    const requestedTargetOffset =
+        shouldRecomputeEndTarget && index !== undefined
+            ? calculateOffsetWithOffsetPosition(ctx, calculateOffsetForIndex(ctx, index), scrollingTo)
+            : (scrollingTo.targetOffset ??
+              clampScrollOffset(ctx, scrollingTo.offset - (scrollingTo.viewOffset || 0), scrollingTo));
+
+    return clampScrollOffset(ctx, requestedTargetOffset, scrollingTo);
+}
+
+export function scrollToFallbackOffset(ctx: StateContext, offset: number) {
+    ctx.state.refScroller.current?.scrollTo({
+        animated: false,
+        x: ctx.state.props.horizontal ? offset : 0,
+        y: ctx.state.props.horizontal ? 0 : offset,
+    });
+}

--- a/src/core/endAlignedScrollTarget.ts
+++ b/src/core/endAlignedScrollTarget.ts
@@ -5,6 +5,8 @@ import type { StateContext } from "@/state/state";
 
 type ActiveScrollTarget = NonNullable<StateContext["state"]["scrollingTo"]>;
 
+const ANIMATED_CORRECTION_MIN_DISTANCE = 40;
+
 export function isEndAlignedLastItemTarget(ctx: StateContext, scrollingTo: ActiveScrollTarget) {
     return scrollingTo.index === ctx.state.props.data.length - 1 && scrollingTo.viewPosition === 1;
 }
@@ -21,9 +23,9 @@ export function getCurrentTargetOffset(ctx: StateContext, scrollingTo: ActiveScr
     return clampScrollOffset(ctx, requestedTargetOffset, scrollingTo);
 }
 
-export function scrollToFallbackOffset(ctx: StateContext, offset: number) {
+export function scrollToFallbackOffset(ctx: StateContext, offset: number, animated = false) {
     ctx.state.refScroller.current?.scrollTo({
-        animated: false,
+        animated,
         x: ctx.state.props.horizontal ? offset : 0,
         y: ctx.state.props.horizontal ? 0 : offset,
     });
@@ -33,9 +35,12 @@ export function scrollToFallbackOffset(ctx: StateContext, offset: number) {
 // end-aligned scroll already settled: while the scroll was active the native
 // container still had the previous committed size, so the dispatched target sat
 // beyond the reachable range and retries could not move past it. Once the
-// committed size lands natively (two frames), re-dispatch a single unanimated
-// correction toward the end. One-shot and end-directed, so it cannot loop or
-// fight the user.
+// committed size lands natively (two frames), re-dispatch a single correction
+// toward the end. One-shot and end-directed, so it cannot loop or fight the
+// user. A large remainder on an animated session means the original dispatch
+// was clamped short (uncommitted size or end inset), so the correction glides
+// instead of teleporting; small residue snaps instantly to keep the settle
+// imperceptible.
 export function maybeCorrectEndAlignedScrollAfterCommit(ctx: StateContext, scrollingTo: ActiveScrollTarget) {
     const state = ctx.state;
     if (!isEndAlignedLastItemTarget(ctx, scrollingTo)) {
@@ -49,7 +54,9 @@ export function maybeCorrectEndAlignedScrollAfterCommit(ctx: StateContext, scrol
             }
             const correctedTarget = getCurrentTargetOffset(ctx, scrollingTo);
             if (correctedTarget > state.scroll + 1) {
-                scrollToFallbackOffset(ctx, correctedTarget);
+                const animated =
+                    !!scrollingTo.animated && correctedTarget - state.scroll > ANIMATED_CORRECTION_MIN_DISTANCE;
+                scrollToFallbackOffset(ctx, correctedTarget, animated);
             }
         });
     });

--- a/src/core/endAlignedScrollTarget.ts
+++ b/src/core/endAlignedScrollTarget.ts
@@ -28,3 +28,29 @@ export function scrollToFallbackOffset(ctx: StateContext, offset: number) {
         y: ctx.state.props.horizontal ? 0 : offset,
     });
 }
+
+// Committing pendingTotalSize in finishScrollTo can grow the content after an
+// end-aligned scroll already settled: while the scroll was active the native
+// container still had the previous committed size, so the dispatched target sat
+// beyond the reachable range and retries could not move past it. Once the
+// committed size lands natively (two frames), re-dispatch a single unanimated
+// correction toward the end. One-shot and end-directed, so it cannot loop or
+// fight the user.
+export function maybeCorrectEndAlignedScrollAfterCommit(ctx: StateContext, scrollingTo: ActiveScrollTarget) {
+    const state = ctx.state;
+    if (!isEndAlignedLastItemTarget(ctx, scrollingTo)) {
+        return;
+    }
+
+    requestAnimationFrame(() => {
+        requestAnimationFrame(() => {
+            if (state.scrollingTo) {
+                return;
+            }
+            const correctedTarget = getCurrentTargetOffset(ctx, scrollingTo);
+            if (correctedTarget > state.scroll + 1) {
+                scrollToFallbackOffset(ctx, correctedTarget);
+            }
+        });
+    });
+}

--- a/src/core/finishScrollTo.ts
+++ b/src/core/finishScrollTo.ts
@@ -1,4 +1,5 @@
 import { addTotalSize } from "@/core/addTotalSize";
+import { maybeCorrectEndAlignedScrollAfterCommit } from "@/core/endAlignedScrollTarget";
 import { finishInitialScroll } from "@/core/finishInitialScroll";
 import { recalculateSettledScroll } from "@/core/recalculateSettledScroll";
 import { PlatformAdjustBreaksScroll } from "@/platform/Platform";
@@ -45,6 +46,7 @@ export function finishScrollTo(ctx: StateContext) {
         }
 
         recalculateSettledScroll(ctx);
+        maybeCorrectEndAlignedScrollAfterCommit(ctx, scrollingTo);
         resolvePendingScroll?.();
     }
 }

--- a/src/types.internal.ts
+++ b/src/types.internal.ts
@@ -247,6 +247,8 @@ export interface InternalState {
     timeouts: Set<number>;
     timeoutSetPaddingTop?: any;
     timeoutCheckFinishedScrollFallback?: any;
+    fallbackScrollSession?: InternalScrollTarget | undefined;
+    fallbackScrollSessionChecks?: number;
     totalSize: number;
     triggerCalculateItemsInView?: (params?: {
         doMVCP?: boolean;

--- a/src/types.internal.ts
+++ b/src/types.internal.ts
@@ -89,6 +89,7 @@ type BootstrapInitialScrollSession = {
 };
 
 type InternalScrollTarget = ScrollTarget & {
+    fallbackChecks?: number;
     waitForInitialScrollCompletionFrame?: boolean;
 };
 
@@ -247,8 +248,6 @@ export interface InternalState {
     timeouts: Set<number>;
     timeoutSetPaddingTop?: any;
     timeoutCheckFinishedScrollFallback?: any;
-    fallbackScrollSession?: InternalScrollTarget | undefined;
-    fallbackScrollSessionChecks?: number;
     totalSize: number;
     triggerCalculateItemsInView?: (params?: {
         doMVCP?: boolean;


### PR DESCRIPTION
Four related fixes for `scrollToEnd`-style (end-aligned, last-item, `viewPosition: 1`) scroll sessions, found while debugging an AI-chat screen built on `KeyboardAwareLegendList` + `anchoredEndSpace` + streaming responses. Instrumented logs for each mechanism are included below. Builds on the target-recompute machinery from `eefb9c5b` (iOS retry when measurements shift the target).

## 1. `fix: correct end-aligned scroll position after pendingTotalSize commits`

`getContentSize` prefers `state.pendingTotalSize`, but the pending size is committed to the rendered container only in `finishScrollTo`. During a programmatic scroll this deadlocks: the dispatched target assumes the pending size, the native container keeps the previous committed size until the scroll finishes, and the native view clamps every dispatch — including fallback retries — to the smaller reachable range.

Observed (chat send): `target 2095`, `contentSize 2892`, scroll pinned at `2071` — short by exactly the uncommitted delta — with 5 futile retries before the check cap finished the session. With chunks arriving during an animated scroll the delta grows to hundreds of px, and with an `anchoredEndSpace` end inset the miss becomes permanent (content shrink and inset growth cancel, so `maxScroll` never moves).

Fix: after `finishScrollTo` commits the pending size for a non-initial end-aligned target, wait two frames and re-dispatch one scroll to the freshly recomputed end target. One-shot, bails if a new session started, only scrolls toward the end.

## 2. `fix: bound the scroll-completion fallback watchdog per session`

`checkFinishedScrollFallback` armed new watchdog closures without clearing pending ones, so each re-arm leaked a concurrent retry loop; with an unreachable target this multiplied into thousands of live 100ms timers issuing native dispatches. Clearing on re-arm alone is insufficient (the closure-local `numChecks` resets forever under continuous re-arms), so the check count is also carried on the `scrollingTo` session itself with a hard cap.

## 3. `fix: complete end-aligned scrolls within slack instead of pixel-chasing`

While content streams into the last item the recomputed end target moves on every measurement and stays ~one uncommitted delta out of native reach, so the `< 1` completion check can never pass — the watchdog re-dispatches against a moving target, which is visible jumping during streaming. End-aligned targets now resolve within a small slack; the post-commit correction from (1) snaps the exact position once afterwards.

## 4. `fix: keep end-aligned retries animated for animated scroll sessions`

iOS clamps `setContentOffset:animated:` to the natively committed range at dispatch time. A chat send grows the `anchoredEndSpace` end inset in the same tick that dispatches `scrollToEnd({ animated: true })`, so the animation launches before the inset commits and stalls short of the target (observed: request `6003`, clamp at `5804`, inset grew `0 → 596` a frame later). Both recovery paths — the unaligned-end-scroll watchdog retry and the post-commit correction from (1) — then re-dispatched with `animated: false`: the sent message teleports to its anchor instead of finishing the requested glide.

Fix: a single `redispatchEndAlignedTarget` helper owns the re-dispatch policy for both sites: an animated session whose remainder exceeds the completion slack from (3) glides the rest of the way; smaller remainders snap instantly so the exact-position settle stays imperceptible.

Log signature without the fix: a continuous offset stream that stalls for ~100ms, then a single large `animated: false` dispatch.

### Repro (existing fixture, iOS simulator)

1. Run the `example` app and open the `ai-chat-keyboard` fixture.
2. Scroll to the very bottom.
3. Type any message and press Send.

When the send grows the anchored end space (the first send of a session, or after the previous response consumed its blank space), the sent message jumps to the top anchor instantly instead of animating up. With the fix it glides the full distance. Reproduced consistently in a production chat screen with the same anchor pattern; verified fixed there via patch-package on 3.3.2.

### Before / After (production chat screen, iOS simulator)

<table>
<tr>
<th>Before</th>
<th>After</th>
</tr>
<tr>
<td>

https://github.com/user-attachments/assets/1a3dd7b8-9f77-4cf5-a3be-641b7cb3ef1a

</td>
<td>

https://github.com/user-attachments/assets/562b48ac-c15b-4239-80f0-33350b20493f

</td>
</tr>
</table>

## Notes

- First commit is a pure refactor (extracts `isEndAlignedLastItemTarget`/`getCurrentTargetOffset`/`scrollToFallbackOffset` into a module both `checkFinishedScroll` and `finishScrollTo` can import without a cycle).
- `bun run tsc:src`, `biome check`, and `bun test` pass — `checkFinishedScroll.test.ts` 16/16 including the `eefb9c5b` regression test and animated/unanimated retry coverage, plus a new `endAlignedScrollTarget.test.ts` (5 tests) covering the post-commit correction; the 3 failures in `calculateItemsInView.test.ts` are pre-existing on `main`.
- Two further findings from the same investigation, happy to file as separate issues: (a) `maintainVisibleContentPosition: {size: true}` accumulates `scrollAdjust` per stream chunk while pinned at an anchored end (observed 28 → 244), displacing rendered content; (b) fresh items are seeded with the average measured size, so `anchoredEndSpace` computed before real measurement can dispatch against phantom sizes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

