### PR TITLE
feat: KeyboardAwareLegendList forwards onContentInsetChange

### DIFF
--- a/src/integrations/keyboard.tsx
+++ b/src/integrations/keyboard.tsx
@@ -24,13 +24,7 @@ if (typeof __DEV__ !== "undefined" && __DEV__ && !KeyboardChatScrollView) {
 
 type KeyboardChatScrollViewPropsUnique = Omit<
     KeyboardChatScrollViewProps,
-    | keyof ScrollViewProps
-    | "inverted"
-    | "ScrollViewComponent"
-    | "blankSpace"
-    | "extraContentPadding"
-    | "onContentInsetChange"
-    | "offset"
+    keyof ScrollViewProps | "inverted" | "ScrollViewComponent" | "blankSpace" | "extraContentPadding" | "offset"
 >;
 
 type KeyboardAwareLegendListProps<ItemT> = Omit<
@@ -146,6 +140,7 @@ export const KeyboardAwareLegendList = typedForwardRef(function KeyboardAwareLeg
         freeze,
         keyboardLiftBehavior,
         keyboardOffset,
+        onContentInsetChange: onContentInsetChangeProp,
         ...rest
     } = props;
 
@@ -174,9 +169,13 @@ export const KeyboardAwareLegendList = typedForwardRef(function KeyboardAwareLeg
         };
     }, [anchoredEndSpace, blankSpace]);
 
-    const onContentInsetChange = useCallback((insets: KeyboardChatScrollViewContentInsets) => {
-        refLegendList.current?.reportContentInset(insets);
-    }, []);
+    const onContentInsetChange = useCallback(
+        (insets: KeyboardChatScrollViewContentInsets) => {
+            refLegendList.current?.reportContentInset(insets);
+            onContentInsetChangeProp?.(insets);
+        },
+        [onContentInsetChangeProp],
+    );
 
     const memoList = useCallback(
         (scrollProps: ScrollViewProps) => {


### PR DESCRIPTION
Previously `onContentInsetChange` was used internally but it wasn't exposed. Now callers can pass it too (and it doesn't break anything internal)