### PR TITLE
fix: recycling hooks crash when rendered outside of a LegendList

### DIFF
--- a/__tests__/hooks/useRecyclingEffect.test.tsx
+++ b/__tests__/hooks/useRecyclingEffect.test.tsx
@@ -1,0 +1,39 @@
+import { describe, expect, it, mock } from "bun:test";
+import "../setup";
+
+import { useRecyclingEffect, useRecyclingState } from "../../src/state/ContextContainer";
+import TestRenderer, { act } from "../helpers/testRenderer";
+
+describe("recycling hooks outside of a LegendList", () => {
+    it("useRecyclingEffect does not crash and never fires", () => {
+        const effect = mock(() => {});
+
+        function Probe() {
+            useRecyclingEffect(effect);
+            return null;
+        }
+
+        expect(() => {
+            act(() => {
+                TestRenderer.create(<Probe />);
+            });
+        }).not.toThrow();
+        expect(effect).not.toHaveBeenCalled();
+    });
+
+    it("useRecyclingState does not crash and returns the initial value", () => {
+        let value: number | undefined;
+
+        function Probe() {
+            [value] = useRecyclingState(() => 42);
+            return null;
+        }
+
+        expect(() => {
+            act(() => {
+                TestRenderer.create(<Probe />);
+            });
+        }).not.toThrow();
+        expect(value).toBe(42);
+    });
+});

--- a/src/state/state.tsx
+++ b/src/state/state.tsx
@@ -206,7 +206,15 @@ export function useStateContext() {
     return React.useContext(ContextState)!;
 }
 
-function createSelectorFunctionsArr(ctx: StateContext, signalNames: readonly ListenerType[]) {
+function createSelectorFunctionsArr(ctx: StateContext | null, signalNames: readonly ListenerType[]) {
+    if (!ctx) {
+        const emptyValues: any[] = [];
+        return {
+            get: () => emptyValues,
+            subscribe: () => () => {},
+        };
+    }
+
     let lastValues: any[] = [];
     let lastSignalValues: any[] = [];
 
@@ -417,7 +425,7 @@ export function useArr$<
     ListenerTypeValueMap[T8],
 ];
 export function useArr$<T extends ListenerType>(signalNames: readonly [T, ...T[]]): ListenerTypeValueMap[T][] {
-    const ctx = React.useContext(ContextState)!;
+    const ctx = React.useContext(ContextState);
     const signalNamesKey = getSignalNamesKey(signalNames);
     const { subscribe, get } = React.useMemo(
         () => createSelectorFunctionsArr(ctx, getSignalNamesFromKey(signalNamesKey)),
@@ -431,7 +439,7 @@ export function useSelector$<T extends ListenerType, T2>(
     signalName: T,
     selector: (value: ListenerTypeValueMap[T]) => T2,
 ): T2 {
-    const ctx = React.useContext(ContextState)!;
+    const ctx = React.useContext(ContextState);
     const { subscribe, get } = React.useMemo(() => createSelectorFunctionsArr(ctx, [signalName]), [ctx, signalName]);
     const getSelectedValue = React.useCallback(() => selector(get()[0]), [get, selector]);
 


### PR DESCRIPTION
## The bug

Since 3.3.2, calling `useRecyclingEffect` or `useRecyclingState` in a component that is rendered **outside** of a `LegendList` throws:

```
TypeError: Cannot read property 'values' of null
```

This was a regression in 3.3.2's recycling-hooks rework ("Recycled rows update their current item without changing the container context"): the hooks now read the current item through `useArr$` → `createSelectorFunctionsArr`, which dereferences `ctx.values` in `peek$` without checking that the `ContextState` provider exists. In 3.3.0 the hooks only touched the container context, which is null-safe, so shared item components (e.g. a swipeable row used both inside a list and in a plain `ScrollView` or modal) worked fine.

Other hooks in `ContextContainer.ts` already treat this as a supported case ("Fail gracefully if used outside context"), so this restores that behavior for the signal-reading path.

## The fix

`createSelectorFunctionsArr` returns a no-op selector (stable empty array, no-op subscribe) when there is no state context, and `useArr$` / `useSelector$` drop their non-null assertions so the null flows through with correct types. `useContainerItemInfo` already returns `undefined` when there's no container context, so the hooks no-op exactly as they did in 3.3.0.

## Tests

Added `__tests__/hooks/useRecyclingEffect.test.tsx` covering both hooks rendered outside a list — both fail with the `TypeError` before the fix and pass after. Full suite: 1468 pass, 1 pre-existing failure (`LegendList.bootstrapInitialScroll.oldarch.test.ts`, fails identically on clean `main` in my environment). `biome check` clean.

--- 

For the meantime this is the patch I am using to resolve this issue in my apps using 3.3.2 

```
diff --git a/node_modules/@legendapp/list/react-native.js b/node_modules/@legendapp/list/react-native.js
index 338c18f..d1cd341 100644
--- a/node_modules/@legendapp/list/react-native.js
+++ b/node_modules/@legendapp/list/react-native.js
@@ -178,6 +178,14 @@ function useStateContext() {
   return React2__namespace.useContext(ContextState);
 }
 function createSelectorFunctionsArr(ctx, signalNames) {
+  if (!ctx) {
+    const emptyValues = [];
+    return {
+      get: () => emptyValues,
+      subscribe: () => () => {
+      }
+    };
+  }
   let lastValues = [];
   let lastSignalValues = [];
   return {
diff --git a/node_modules/@legendapp/list/react-native.mjs b/node_modules/@legendapp/list/react-native.mjs
index 32c194f..1c6f1d5 100644
--- a/node_modules/@legendapp/list/react-native.mjs
+++ b/node_modules/@legendapp/list/react-native.mjs
@@ -157,6 +157,14 @@ function useStateContext() {
   return React2.useContext(ContextState);
 }
 function createSelectorFunctionsArr(ctx, signalNames) {
+  if (!ctx) {
+    const emptyValues = [];
+    return {
+      get: () => emptyValues,
+      subscribe: () => () => {
+      }
+    };
+  }
   let lastValues = [];
   let lastSignalValues = [];
   return {

```
