### PR TITLE
fix: complete non-zero initialScrollIndex on iOS without waiting for native scroll events

### DIFF
--- a/src/core/checkFinishedScroll.ts
+++ b/src/core/checkFinishedScroll.ts
@@ -58,27 +58,41 @@ function isNativeInitialNonZeroTarget(state: StateContext["state"]) {
     return !state.didFinishInitialScroll && initialScrollWatchdog.hasNonZeroTargetOffset(targetOffset);
 }
 
-function shouldFinishInitialScrollWithoutNativeProgress(state: StateContext["state"], scrollingTo: ActiveScrollTarget) {
+function shouldFinishInitialScrollWithoutNativeProgress(ctx: StateContext, scrollingTo: ActiveScrollTarget) {
+    const { state } = ctx;
     if (!scrollingTo.isInitialScroll || scrollingTo.animated || !state.didContainersLayout) {
         return false;
     }
 
+    const targetOffset = scrollingTo.targetOffset ?? scrollingTo.offset;
+
     // On iOS an unanimated initial scrollTo/contentOffset does NOT emit a
     // scroll event, so gating completion on observing native scroll progress
-    // deadlocks: the fallback loop re-issues scrollTo to the same offset
-    // (which again emits nothing) until the watchdog gives up seconds later —
-    // all while the list is held at opacity 0. When state.scroll and
-    // state.scrollPending already match the target (checked below), the
-    // unanimated dispatch has been applied synchronously and it is safe to
-    // finish without native progress. Other platforms emit the event and keep
-    // the stricter gate.
-    if (Platform.OS !== "ios" && state.initialScrollSession?.kind === "bootstrap") {
+    // deadlocks plain initial targets: the fallback loop re-issues scrollTo to
+    // the same offset (which again emits nothing) until the watchdog gives up
+    // seconds later — all while the list is held at opacity 0.
+    //
+    // state.scroll is set optimistically at dispatch (doScrollTo.native.ts),
+    // so it is only trustworthy when the requested offset was actually
+    // applicable: a plain target (no viewOffset/viewPosition adjustment —
+    // those are recomputed on retries) that lies within the currently
+    // scrollable range (so native cannot have clamped it short). End-aligned /
+    // initialScrollAtEnd targets with footers can exceed the max scroll until
+    // late layout and must keep waiting for confirmed native progress, which
+    // their recomputed-offset retries do produce.
+    const maxScrollOffset = getContentSize(ctx) - state.scrollLength;
+    const canTrustDispatchedOffsetOnIOS =
+        Platform.OS === "ios" &&
+        !scrollingTo.viewOffset &&
+        !scrollingTo.viewPosition &&
+        targetOffset <= maxScrollOffset + 1;
+
+    if (!canTrustDispatchedOffsetOnIOS && state.initialScrollSession?.kind === "bootstrap") {
         return false;
     }
 
-    const targetOffset = scrollingTo.targetOffset ?? scrollingTo.offset;
     if (
-        Platform.OS !== "ios" &&
+        !canTrustDispatchedOffsetOnIOS &&
         initialScrollWatchdog.hasNonZeroTargetOffset(targetOffset) &&
         initialScrollCompletion.didDispatchNativeScroll(state) &&
         !state.hasScrolled
@@ -176,7 +190,7 @@ export function checkFinishedScrollFallback(ctx: StateContext) {
     const shouldFinishInitialZeroTarget = shouldFinishInitialZeroTargetScroll(ctx);
     const silentInitialDispatch = isSilentInitialDispatch(state, scrollingTo);
     const canFinishInitialWithoutNativeProgress =
-        scrollingTo !== undefined ? shouldFinishInitialScrollWithoutNativeProgress(state, scrollingTo) : false;
+        scrollingTo !== undefined ? shouldFinishInitialScrollWithoutNativeProgress(ctx, scrollingTo) : false;
     const slowTimeout =
         (scrollingTo?.isInitialScroll && !shouldFinishInitialZeroTarget && !canFinishInitialWithoutNativeProgress) ||
         !state.didContainersLayout;
@@ -208,7 +222,7 @@ export function checkFinishedScrollFallback(ctx: StateContext) {
                       : 5;
                 const shouldFinishZeroTarget = shouldFinishInitialZeroTargetScroll(ctx);
                 const canFinishInitialScrollWithoutNativeProgress = shouldFinishInitialScrollWithoutNativeProgress(
-                    state,
+                    ctx,
                     isStillScrollingTo,
                 );
                 const completionState = getResolvedScrollCompletionState(ctx, isStillScrollingTo);

--- a/src/core/checkFinishedScroll.ts
+++ b/src/core/checkFinishedScroll.ts
@@ -63,12 +63,22 @@ function shouldFinishInitialScrollWithoutNativeProgress(state: StateContext["sta
         return false;
     }
 
-    if (state.initialScrollSession?.kind === "bootstrap") {
+    // On iOS an unanimated initial scrollTo/contentOffset does NOT emit a
+    // scroll event, so gating completion on observing native scroll progress
+    // deadlocks: the fallback loop re-issues scrollTo to the same offset
+    // (which again emits nothing) until the watchdog gives up seconds later —
+    // all while the list is held at opacity 0. When state.scroll and
+    // state.scrollPending already match the target (checked below), the
+    // unanimated dispatch has been applied synchronously and it is safe to
+    // finish without native progress. Other platforms emit the event and keep
+    // the stricter gate.
+    if (Platform.OS !== "ios" && state.initialScrollSession?.kind === "bootstrap") {
         return false;
     }
 
     const targetOffset = scrollingTo.targetOffset ?? scrollingTo.offset;
     if (
+        Platform.OS !== "ios" &&
         initialScrollWatchdog.hasNonZeroTargetOffset(targetOffset) &&
         initialScrollCompletion.didDispatchNativeScroll(state) &&
         !state.hasScrolled


### PR DESCRIPTION
## Problem

On iOS, a list mounted with a **non-zero `initialScrollIndex`** stays invisible (the `readyToRender` opacity gate) for seconds — in our production app we consistently measured **2.8–3.8s** before the list appeared, while its content was mounted, laid out, and (in our case) already playing video/audio underneath.

## Root cause

The initial-scroll completion logic deadlocks on iOS:

1. The initial scroll is dispatched as an unanimated `scrollTo`/`contentOffset`. **iOS does not emit a scroll event for unanimated offset changes**, so `state.hasScrolled` never becomes true and `didDispatchNativeScroll` keeps gating.
2. `shouldFinishInitialScrollWithoutNativeProgress` refuses to finish while `didDispatchNativeScroll(state) && !state.hasScrolled` (and unconditionally for `bootstrap` sessions) — even when `state.scroll` and `state.scrollPending` already match the target exactly.
3. The fallback loop in `checkFinishedScroll` then re-issues `scrollToFallbackOffset` to the **same offset** — which again emits no event, because the offset doesn't change.
4. The loop burns through its retries until the watchdog gives up (~2–4s depending on timing), and only then does `readyToRender` flip and the list appear.

Which of the two refusals bites depends on mount timing (session kind ends up `bootstrap` on some mounts and `offset` on others), which makes the stall look intermittent — that's what made it painful to track down.

## Fix

On iOS only, allow `shouldFinishInitialScrollWithoutNativeProgress` to finish without observed native progress — the existing offset checks right below (`state.scroll` and `state.scrollPending` within 1px of the target) remain the real gate, and they're reliable there because unanimated `scrollTo` applies synchronously. Android/web still emit the events and keep the stricter path, so their behavior is unchanged.

After the fix our reveal times went from 2.8–3.8s to a consistent **120–370ms** across dozens of cold mounts (production app, iPhone 13 / iOS 26, ~60-item list with fixed item heights, `initialScrollIndex` typically 1–10).

## Repro

- iOS device or simulator
- `<LegendList data={items} initialScrollIndex={8} estimatedItemSize={FIXED} …/>` where the list mounts with data already present
- Observe `onLoad` timing / the list staying blank for seconds before appearing (worse on slower devices; timing-dependent, so try several mounts)

## Notes

- I scoped both bypasses to `Platform.OS === "ios"` to keep the blast radius minimal, but if you'd prefer the offset-match check to be authoritative on all platforms (or a different structure entirely), happy to rework.
- Wasn't able to run `bun test` in this environment; the change has been running in a production app for a full day of heavy manual testing (cold mounts, remounts, in-place data swaps via `dataKey`, user scrolls immediately after mount) with no regressions observed.
