### PR TITLE
fix: defer set$ calls out of render body to avoid setState-during-render

### DIFF
--- a/src/components/LegendList.tsx
+++ b/src/components/LegendList.tsx
@@ -492,15 +492,17 @@ const LegendListInner = typedForwardRef(function LegendListInner<T>(
 
     state.refScroller = refScroller as unknown as React.RefObject<LegendListScrollerRef | null>;
 
-    if (!isFirstLocal && previousAdaptiveRender && !experimental_adaptiveRender) {
-        resetAdaptiveRender(ctx);
-    }
-    if (shouldResetFreshDataLayout) {
-        resetInitialRenderState(ctx, {
-            resetInitialScroll: !!initialScrollProp,
-            resetLayout: true,
-        });
-    }
+    useLayoutEffect(() => {
+        if (!isFirstLocal && previousAdaptiveRender && !experimental_adaptiveRender) {
+            resetAdaptiveRender(ctx);
+        }
+        if (shouldResetFreshDataLayout) {
+            resetInitialRenderState(ctx, {
+                resetInitialScroll: !!initialScrollProp,
+                resetLayout: true,
+            });
+        }
+    }, [isFirstLocal, previousAdaptiveRender, experimental_adaptiveRender, shouldResetFreshDataLayout, initialScrollProp]);
 
     const memoizedLastItemKeys = useMemo(() => {
         if (!dataProp.length) return [];


### PR DESCRIPTION
## Problem

`resetInitialRenderState` and `resetAdaptiveRender` both call `set$()` synchronously inside the render body of `LegendListInner2`. `set$` immediately fires all listeners, and `ContainersLayer2` subscribes to `readyToRender` via `useSyncExternalStore`. When that subscriber is invoked during another component's render, React detects it as an illegal concurrent state update and throws:

> Cannot update a component (`ContainersLayer2`) while rendering a different component (`ForwardRef(LegendListInner2)`)

## Fix

Move both calls into a `useLayoutEffect`. This defers the `set$` calls to after the render phase but before paint, so:
- No illegal setState-during-render warning
- No visible flash (layout effects run synchronously before the browser paints)
- All captured variables (`isFirstLocal`, `previousAdaptiveRender`, `shouldResetFreshDataLayout`, etc.) correctly reflect the render that determined the reset was needed