### PR TITLE
Fix stale containers rendering removed data

### DIFF
--- a/__tests__/components/ContainerSlot.test.tsx
+++ b/__tests__/components/ContainerSlot.test.tsx
@@ -21,9 +21,11 @@ function Setup({ children, itemKey }: { children: React.ReactNode; itemKey?: str
 }
 
 function renderSlot({
+    activeItemKeys,
     itemKey,
     onContainerRender,
 }: {
+    activeItemKeys?: ReadonlySet<string>;
     itemKey?: string;
     onContainerRender: (props: ContainerComponentProps<unknown>) => void;
 }) {
@@ -40,6 +42,7 @@ function renderSlot({
             <StateProvider>
                 <Setup itemKey={itemKey}>
                     <ContainerSlotBase
+                        activeItemKeys={activeItemKeys ?? new Set(["item-0", "item-1"])}
                         ContainerComponent={MockContainer}
                         getRenderedItem={() => null}
                         horizontal={false}
@@ -135,6 +138,52 @@ describe("ContainerSlot", () => {
 
         act(() => {
             renderer.unmount();
+        });
+    });
+
+    it("unmounts a Container whose assigned item key is absent from the latest data", () => {
+        const renderedProps: ContainerComponentProps<unknown>[] = [];
+        const onContainerRender = (props: ContainerComponentProps<unknown>) => renderedProps.push(props);
+        const itemKey = "item-0";
+
+        function MockContainer(props: ContainerComponentProps<unknown>) {
+            onContainerRender(props);
+            return React.createElement("mock-container", { itemKey: props.itemKey });
+        }
+
+        const render = (activeItemKeys: ReadonlySet<string>) => (
+            <StateProvider>
+                <Setup itemKey={itemKey}>
+                    <ContainerSlotBase
+                        activeItemKeys={activeItemKeys}
+                        ContainerComponent={MockContainer}
+                        getRenderedItem={() => null}
+                        horizontal={false}
+                        id={0}
+                        recycleItems={false}
+                    />
+                </Setup>
+            </StateProvider>
+        );
+
+        let renderer: TestRenderer.ReactTestRenderer | undefined;
+        act(() => {
+            renderer = TestRenderer.create(render(new Set([itemKey])));
+        });
+
+        expect(renderer!.toJSON()).toMatchObject({
+            props: { itemKey },
+        });
+
+        act(() => {
+            renderer!.update(render(new Set()));
+        });
+
+        expect(renderer!.toJSON()).toBeNull();
+        expect(renderedProps).toHaveLength(1);
+
+        act(() => {
+            renderer!.unmount();
         });
     });
 });

--- a/__tests__/components/Containers.native.test.tsx
+++ b/__tests__/components/Containers.native.test.tsx
@@ -40,7 +40,12 @@ describe("Containers gap handling", () => {
         const { toJSON, unmount } = render(
             <StateProvider>
                 <Setup columnWrapperStyle={{ gap: 20 }} numColumns={1}>
-                    <Containers getRenderedItem={() => null} horizontal={false} recycleItems={false} />
+                    <Containers
+                        activeItemKeys={new Set()}
+                        getRenderedItem={() => null}
+                        horizontal={false}
+                        recycleItems={false}
+                    />
                 </Setup>
             </StateProvider>,
         );
@@ -58,7 +63,12 @@ describe("Containers gap handling", () => {
         const { toJSON, unmount } = render(
             <StateProvider>
                 <Setup columnWrapperStyle={{ gap: 16 }} numColumns={2}>
-                    <Containers getRenderedItem={() => null} horizontal={false} recycleItems={false} />
+                    <Containers
+                        activeItemKeys={new Set()}
+                        getRenderedItem={() => null}
+                        horizontal={false}
+                        recycleItems={false}
+                    />
                 </Setup>
             </StateProvider>,
         );
@@ -76,7 +86,12 @@ describe("Containers gap handling", () => {
         const { toJSON, unmount } = render(
             <StateProvider>
                 <Setup columnWrapperStyle={{}} numColumns={1}>
-                    <Containers getRenderedItem={() => null} horizontal recycleItems={false} />
+                    <Containers
+                        activeItemKeys={new Set()}
+                        getRenderedItem={() => null}
+                        horizontal
+                        recycleItems={false}
+                    />
                 </Setup>
             </StateProvider>,
         );
@@ -94,7 +109,12 @@ describe("Containers gap handling", () => {
         const { toJSON, unmount } = render(
             <StateProvider>
                 <Setup columnWrapperStyle={{}} numColumns={1} otherAxisSize={180}>
-                    <Containers getRenderedItem={() => null} horizontal recycleItems={false} />
+                    <Containers
+                        activeItemKeys={new Set()}
+                        getRenderedItem={() => null}
+                        horizontal
+                        recycleItems={false}
+                    />
                 </Setup>
             </StateProvider>,
         );

--- a/__tests__/components/Containers.web.test.ts
+++ b/__tests__/components/Containers.web.test.ts
@@ -46,6 +46,7 @@ async function renderContainers(horizontal: boolean, readyToRender = true) {
                         readyToRender,
                     },
                     React.createElement(Containers, {
+                        activeItemKeys: new Set(),
                         getRenderedItem: () => null,
                         horizontal,
                         recycleItems: true,

--- a/__tests__/components/LegendList.bootstrapInitialScroll.test.tsx
+++ b/__tests__/components/LegendList.bootstrapInitialScroll.test.tsx
@@ -26,6 +26,7 @@ function registerLegendListBootstrapMocks() {
             const Containers = WebContainers;
             return Containers ? (
                 <Containers
+                    activeItemKeys={props.activeItemKeys}
                     getRenderedItem={props.getRenderedItem}
                     horizontal={props.horizontal}
                     ItemSeparatorComponent={props.ItemSeparatorComponent}

--- a/__tests__/components/ListComponent.renderScrollComponent.test.tsx
+++ b/__tests__/components/ListComponent.renderScrollComponent.test.tsx
@@ -75,6 +75,7 @@ function ListComponentHarness({
 
     return (
         <ListComponent
+            activeItemKeys={new Set()}
             canRender={false}
             drawDistance={0}
             estimatedItemSize={100}

--- a/src/components/ContainerSlot.tsx
+++ b/src/components/ContainerSlot.tsx
@@ -17,10 +17,12 @@ export interface ContainerComponentProps<ItemT> {
 }
 
 export interface ContainerSlotProps<ItemT> extends Omit<ContainerComponentProps<ItemT>, "itemKey"> {
+    activeItemKeys: ReadonlySet<string>;
     ContainerComponent?: React.ComponentType<ContainerComponentProps<ItemT>>;
 }
 
 export function ContainerSlotBase<ItemT>({
+    activeItemKeys,
     id,
     horizontal,
     recycleItems,
@@ -31,7 +33,7 @@ export function ContainerSlotBase<ItemT>({
 }: ContainerSlotProps<ItemT>) {
     const [itemKey] = useArr$([`containerItemKey${id}`]);
 
-    if (itemKey === undefined) {
+    if (itemKey === undefined || !activeItemKeys.has(itemKey)) {
         return null;
     }
 

--- a/src/components/Containers.native.tsx
+++ b/src/components/Containers.native.tsx
@@ -9,6 +9,7 @@ import type { StickyHeaderConfig } from "@/types.base";
 import { type GetRenderedItem, typedMemo } from "@/types.internal";
 
 interface ContainersProps<ItemT> {
+    activeItemKeys: ReadonlySet<string>;
     horizontal: boolean;
     recycleItems: boolean;
     ItemSeparatorComponent?: React.ComponentType<{ leadingItem: ItemT }>;
@@ -65,6 +66,7 @@ const ContainersLayer = typedMemo(function ContainersLayer({ children, horizonta
 
 // biome-ignore lint/nursery/noShadow: const function name shadowing is intentional
 export const Containers = typedMemo(function Containers<ItemT>({
+    activeItemKeys,
     horizontal,
     recycleItems,
     ItemSeparatorComponent,
@@ -77,6 +79,7 @@ export const Containers = typedMemo(function Containers<ItemT>({
     for (let i = 0; i < numContainersPooled; i++) {
         containers.push(
             <ContainerSlot
+                activeItemKeys={activeItemKeys}
                 getRenderedItem={getRenderedItem}
                 horizontal={horizontal}
                 ItemSeparatorComponent={ItemSeparatorComponent}

--- a/src/components/Containers.tsx
+++ b/src/components/Containers.tsx
@@ -10,6 +10,7 @@ import { type GetRenderedItem, typedMemo } from "@/types.internal";
 import { isHorizontalRTL } from "@/utils/rtl";
 
 interface ContainersProps<ItemT> {
+    activeItemKeys: ReadonlySet<string>;
     horizontal: boolean;
     recycleItems: boolean;
     ItemSeparatorComponent?: React.ComponentType<{ leadingItem: ItemT }>;
@@ -77,6 +78,7 @@ const ContainersInner = typedMemo(function ContainersInner({ horizontal, numColu
 
 // biome-ignore lint/nursery/noShadow: const function name shadowing is intentional
 export const Containers = typedMemo(function Containers<ItemT>({
+    activeItemKeys,
     horizontal,
     recycleItems,
     ItemSeparatorComponent,
@@ -89,6 +91,7 @@ export const Containers = typedMemo(function Containers<ItemT>({
     for (let i = 0; i < numContainersPooled; i++) {
         containers.push(
             <ContainerSlot
+                activeItemKeys={activeItemKeys}
                 getRenderedItem={getRenderedItem}
                 horizontal={horizontal}
                 ItemSeparatorComponent={ItemSeparatorComponent}

--- a/src/components/LegendList.tsx
+++ b/src/components/LegendList.tsx
@@ -279,6 +279,10 @@ const LegendListInner = typedForwardRef(function LegendListInner<T>(
     const refScroller = useRef<LooseScrollView>(null);
     const combinedRef = useCombinedRef(refScroller, refScrollView);
     const keyExtractor = keyExtractorProp ?? ((_item: T, index: number) => index.toString());
+    const activeItemKeys = useMemo(() => {
+        const extractKey = keyExtractorProp ?? ((_item: T, index: number) => index.toString());
+        return new Set(dataProp.map((item, index) => extractKey(item, index)));
+    }, [dataProp, dataKey, dataVersion, keyExtractorProp]);
     const stickyHeaderIndices = stickyHeaderIndicesProp;
     const contentInsetEndAdjustmentResolved = Platform.OS === "web" ? contentInsetEndAdjustment : undefined;
     const previousContentInsetEndAdjustmentRef = useRef(contentInsetEndAdjustmentResolved);
@@ -827,6 +831,7 @@ const LegendListInner = typedForwardRef(function LegendListInner<T>(
         <>
             <ListComponent
                 {...restProps}
+                activeItemKeys={activeItemKeys}
                 alignItemsAtEnd={alignItemsAtEnd}
                 canRender={canRender}
                 contentContainerStyle={contentContainerStyle}

--- a/src/components/ListComponent.tsx
+++ b/src/components/ListComponent.tsx
@@ -44,6 +44,7 @@ interface ListComponentProps<ItemT>
         | "renderScrollComponent"
         | "style"
     > {
+    activeItemKeys: ReadonlySet<string>;
     horizontal: boolean;
     initialContentOffset: number | undefined;
     refScrollView: React.Ref<LooseScrollView | null>;
@@ -83,6 +84,7 @@ const AlignItemsAtEndSpacer = typedMemo(function AlignItemsAtEndSpacer({ horizon
 
 // biome-ignore lint/nursery/noShadow: const function name shadowing is intentional
 export const ListComponent = typedMemo(function ListComponent<ItemT>({
+    activeItemKeys,
     canRender,
     style,
     contentContainerStyle,
@@ -213,6 +215,7 @@ export const ListComponent = typedMemo(function ListComponent<ItemT>({
 
             {canRender && !ListEmptyComponent && (
                 <Containers
+                    activeItemKeys={activeItemKeys}
                     getRenderedItem={getRenderedItem}
                     horizontal={horizontal!}
                     ItemSeparatorComponent={ItemSeparatorComponent}


### PR DESCRIPTION
Fixes #503

## Summary

- Derive the current item-key set from the latest `data` props during render.
- Stop a `ContainerSlot` from rendering when its allocated key is no longer present, before layout-effect reconciliation clears the allocation signal.
- Preserve containers for retained keys so their row subtrees remain mounted.
- Cover the stale-allocation window with a focused regression test and update internal component fixtures for the new invariant.

This prevents rows backed by an external store, including Relay optimistic records, from rendering after the same update removes both the list item and its backing record.

## Why this happens

Container allocation is intentionally reconciled in a layout effect. An independently subscribed row can therefore render during the preceding React render while `containerItemKey` still points at removed data. Checking membership against the latest data at the slot boundary closes that window without moving signal writes into render.

## Validation

- `bun run lint`
- `bun run tsc:src`
- `bun test` — 1,466 passing
- `bun run build`