### PR TITLE
fix: cancel scroll completion checks on unmount

### DIFF
--- a/__tests__/components/LegendList.props.test.tsx
+++ b/__tests__/components/LegendList.props.test.tsx
@@ -8,6 +8,7 @@ let lastListProps: any;
 let requestAdjustCalls: number[] = [];
 let scrollToCalls: any[] = [];
 
+import { checkFinishedScrollFallback } from "../../src/core/checkFinishedScroll";
 import { finishScrollTo } from "../../src/core/finishScrollTo";
 import type { ScrollAdjustHandler } from "../../src/core/ScrollAdjustHandler";
 import { type StateContext, set$ } from "../../src/state/state";
@@ -205,6 +206,70 @@ describe("LegendList props behavior", () => {
         rendered.unmount();
 
         expect(state.timeouts.size).toBe(0);
+    });
+
+    it("cancels scroll completion checks on unmount", async () => {
+        const data = [{ id: "item-1", label: "Alpha" }];
+        const renderItem = ({ item }: { item: { label: string } }) => <Text>{item.label}</Text>;
+        const { LegendList } = await import("../../src/components/LegendList?props-test-scroll-completion-cleanup");
+        const originalSetTimeout = globalThis.setTimeout;
+        const originalClearTimeout = globalThis.clearTimeout;
+        const originalCancelAnimationFrame = globalThis.cancelAnimationFrame;
+        const pendingTimers = new Map<number, () => void>();
+        const pendingFrames = new Set<number>();
+        let nextTimer = -1;
+
+        try {
+            const rendered = render(
+                <LegendList
+                    data={data}
+                    estimatedItemSize={100}
+                    keyExtractor={(item: { id: string }) => item.id}
+                    recycleItems={false}
+                    renderItem={renderItem}
+                />,
+            );
+            const ctx = await getContextFromRender();
+            const state = ctx.state;
+            state.didContainersLayout = true;
+            state.scrollingTo = {
+                animated: false,
+                isInitialScroll: false,
+                offset: 100,
+                targetOffset: 100,
+                viewOffset: 0,
+            };
+            state.animFrameCheckFinishedScroll = 0;
+            pendingFrames.add(0);
+
+            globalThis.setTimeout = ((callback: TimerHandler) => {
+                nextTimer += 1;
+                pendingTimers.set(nextTimer, callback as () => void);
+                return nextTimer as unknown as ReturnType<typeof setTimeout>;
+            }) as typeof globalThis.setTimeout;
+            globalThis.clearTimeout = ((timer: ReturnType<typeof setTimeout>) => {
+                pendingTimers.delete(timer as unknown as number);
+            }) as typeof globalThis.clearTimeout;
+            globalThis.cancelAnimationFrame = (frame: number) => {
+                pendingFrames.delete(frame);
+            };
+
+            checkFinishedScrollFallback(ctx);
+            const fallbackTimeout = state.timeoutCheckFinishedScrollFallback as number | undefined;
+            expect(fallbackTimeout).toBe(0);
+            expect(pendingTimers.has(fallbackTimeout!)).toBe(true);
+
+            rendered.unmount();
+
+            expect(pendingTimers.has(fallbackTimeout!)).toBe(false);
+            expect(pendingFrames.has(0)).toBe(false);
+            expect(state.animFrameCheckFinishedScroll).toBeUndefined();
+            expect(state.timeoutCheckFinishedScrollFallback).toBeUndefined();
+        } finally {
+            globalThis.setTimeout = originalSetTimeout;
+            globalThis.clearTimeout = originalClearTimeout;
+            globalThis.cancelAnimationFrame = originalCancelAnimationFrame;
+        }
     });
 
     it("cancels queued full drawDistance prewarm on unmount", async () => {

--- a/__tests__/core/checkFinishedScroll.test.ts
+++ b/__tests__/core/checkFinishedScroll.test.ts
@@ -517,22 +517,52 @@ describe("checkFinishedScrollFallback", () => {
 
 describe("checkFinishedScroll", () => {
     let originalPlatform: typeof Platform.OS;
+    let originalCancelAnimationFrame: typeof globalThis.cancelAnimationFrame;
     let originalRequestAnimationFrame: typeof globalThis.requestAnimationFrame;
+    let canceledFrames: number[];
+    let nextFrameHandle: number;
     let pendingFrame: FrameRequestCallback | undefined;
 
     beforeEach(() => {
         originalPlatform = Platform.OS;
+        originalCancelAnimationFrame = globalThis.cancelAnimationFrame;
         originalRequestAnimationFrame = globalThis.requestAnimationFrame;
+        canceledFrames = [];
+        nextFrameHandle = 0;
         pendingFrame = undefined;
+        globalThis.cancelAnimationFrame = (frame: number) => {
+            canceledFrames.push(frame);
+        };
         globalThis.requestAnimationFrame = ((callback: FrameRequestCallback) => {
             pendingFrame = callback;
-            return 1;
+            return nextFrameHandle++;
         }) as typeof globalThis.requestAnimationFrame;
     });
 
     afterEach(() => {
         Platform.OS = originalPlatform;
+        globalThis.cancelAnimationFrame = originalCancelAnimationFrame;
         globalThis.requestAnimationFrame = originalRequestAnimationFrame;
+    });
+
+    it("cancels a pending completion frame before scheduling another", () => {
+        const ctx = createMockContext(
+            {},
+            {
+                scrollingTo: {
+                    animated: false,
+                    isInitialScroll: false,
+                    offset: 100,
+                    viewOffset: 0,
+                } as any,
+            },
+        );
+
+        checkFinishedScroll(ctx);
+        checkFinishedScroll(ctx);
+
+        expect(canceledFrames).toEqual([0]);
+        expect(ctx.state.animFrameCheckFinishedScroll).toBe(1);
     });
 
     it("finishes when the scroll reaches the resolved end clamp target", () => {

--- a/__tests__/core/scrollTo.test.ts
+++ b/__tests__/core/scrollTo.test.ts
@@ -45,8 +45,8 @@ describe("scrollTo", () => {
         globalThis.cancelAnimationFrame = ((id: number) => {
             cancelCalls.push(id);
         }) as typeof cancelAnimationFrame;
-        mockCtx.state.animFrameCheckFinishedScroll = 11 as never;
-        mockCtx.state.timeoutCheckFinishedScrollFallback = 22 as never;
+        mockCtx.state.animFrameCheckFinishedScroll = 0 as never;
+        mockCtx.state.timeoutCheckFinishedScrollFallback = 0 as never;
 
         try {
             scrollTo(mockCtx, { animated: true, offset: 60 });
@@ -55,8 +55,10 @@ describe("scrollTo", () => {
             clearTimeoutSpy.mockRestore();
         }
 
-        expect(cancelCalls).toEqual([11]);
-        expect(clearTimeoutCalls).toEqual([22]);
+        expect(cancelCalls).toEqual([0]);
+        expect(clearTimeoutCalls).toEqual([0]);
+        expect(mockCtx.state.animFrameCheckFinishedScroll).toBeUndefined();
+        expect(mockCtx.state.timeoutCheckFinishedScrollFallback).toBeUndefined();
     });
 
     it("keeps initial iOS scrolls local while arming the native watchdog", () => {

--- a/src/components/LegendList.tsx
+++ b/src/components/LegendList.tsx
@@ -20,6 +20,7 @@ import {
     handleBootstrapInitialScrollLayoutChange,
 } from "@/core/bootstrapInitialScroll";
 import { calculateItemsInView } from "@/core/calculateItemsInView";
+import { cancelScrollCompletionChecks } from "@/core/cancelScrollCompletionChecks";
 import { checkFinishedScrollFallback } from "@/core/checkFinishedScroll";
 import { checkResetContainers } from "@/core/checkResetContainers";
 import { checkStructuralDataChange } from "@/core/checkStructuralDataChange";
@@ -782,6 +783,7 @@ const LegendListInner = typedForwardRef(function LegendListInner<T>(
 
     useEffect(() => {
         return () => {
+            cancelScrollCompletionChecks(state);
             if (state.queuedFullDrawDistancePrewarm !== undefined) {
                 cancelAnimationFrame(state.queuedFullDrawDistancePrewarm);
                 state.queuedFullDrawDistancePrewarm = undefined;

--- a/src/core/cancelScrollCompletionChecks.ts
+++ b/src/core/cancelScrollCompletionChecks.ts
@@ -1,0 +1,19 @@
+import type { StateContext } from "@/state/state";
+
+export function cancelScrollCompletionFrame(state: StateContext["state"]) {
+    const animationFrame = state.animFrameCheckFinishedScroll;
+    if (animationFrame !== undefined) {
+        cancelAnimationFrame(animationFrame);
+        state.animFrameCheckFinishedScroll = undefined;
+    }
+}
+
+export function cancelScrollCompletionChecks(state: StateContext["state"]) {
+    cancelScrollCompletionFrame(state);
+
+    const fallbackTimeout = state.timeoutCheckFinishedScrollFallback;
+    if (fallbackTimeout !== undefined) {
+        clearTimeout(fallbackTimeout);
+        state.timeoutCheckFinishedScrollFallback = undefined;
+    }
+}

--- a/src/core/checkFinishedScroll.ts
+++ b/src/core/checkFinishedScroll.ts
@@ -1,5 +1,6 @@
 import { calculateOffsetForIndex } from "@/core/calculateOffsetForIndex";
 import { calculateOffsetWithOffsetPosition } from "@/core/calculateOffsetWithOffsetPosition";
+import { cancelScrollCompletionFrame } from "@/core/cancelScrollCompletionChecks";
 import { clampScrollOffset } from "@/core/clampScrollOffset";
 import { finishScrollTo } from "@/core/finishScrollTo";
 import { initialScrollCompletion, initialScrollWatchdog } from "@/core/initialScrollSession";
@@ -28,6 +29,7 @@ export function checkFinishedScroll(ctx: StateContext, options?: { onlyIfAligned
 
     // Wait a frame because there may be some requestAdjust after this which
     // change things so it would need to wait longer
+    cancelScrollCompletionFrame(ctx.state);
     ctx.state.animFrameCheckFinishedScroll = requestAnimationFrame(() => checkFinishedScrollFrame(ctx));
 }
 

--- a/src/core/scrollTo.ts
+++ b/src/core/scrollTo.ts
@@ -1,4 +1,5 @@
 import { calculateOffsetWithOffsetPosition } from "@/core/calculateOffsetWithOffsetPosition";
+import { cancelScrollCompletionChecks } from "@/core/cancelScrollCompletionChecks";
 import { clampScrollOffset } from "@/core/clampScrollOffset";
 import { doScrollTo } from "@/core/doScrollTo";
 import { initialScrollCompletion, initialScrollWatchdog } from "@/core/initialScrollSession";
@@ -169,13 +170,8 @@ export function scrollTo(
         props: { horizontal },
     } = state;
 
-    // Clear out previous timeouts which would finishScrollTo
-    if (state.animFrameCheckFinishedScroll) {
-        cancelAnimationFrame(ctx.state.animFrameCheckFinishedScroll);
-    }
-    if (state.timeoutCheckFinishedScrollFallback) {
-        clearTimeout(ctx.state.timeoutCheckFinishedScrollFallback);
-    }
+    // Clear out previous callbacks which would finishScrollTo
+    cancelScrollCompletionChecks(state);
 
     const requestedOffset = precomputedWithViewOffset
         ? scrollTargetOffset


### PR DESCRIPTION
## Summary

- cancel the stored scroll-completion animation frame and fallback timeout when `LegendList` unmounts
- cancel a pending completion frame before replacing it so rapid native scroll events cannot orphan an older callback
- reuse the same cleanup when a new programmatic scroll supersedes pending completion work
- clear both stored handles after cancellation, including valid handle `0`

## Root cause

`checkFinishedScrollFallback` stores its watchdog in `timeoutCheckFinishedScrollFallback`, outside the generic `state.timeouts` registry that unmount cleanup clears. The completion animation frame is stored separately as well. Both handles could therefore survive teardown and call back into an unmounted list.

`checkFinishedScroll` could also overwrite the stored animation-frame ID when multiple native scroll events arrived before the next frame. Coalescing completion checks to the latest frame prevents an older callback from becoming unreachable by cleanup.

This addresses the reproduced post-unmount watchdog failure in #508. #485 is complementary work for fallback re-arming during a live session.

## Validation

- `pnpm dlx bun test __tests__/core/checkFinishedScroll.test.ts __tests__/core/scrollTo.test.ts __tests__/components/LegendList.props.test.tsx` (67 passed)
- `pnpm dlx bun run tsc:src`
- `pnpm dlx bun run lint:fix`
- `pnpm dlx bun run lint`
- `pnpm dlx bun test` (1,514 passed)
- `pnpm dlx bun run build`
