### PR TITLE
fix: reapply Android initial scroll after layout

### DIFF
--- a/__tests__/core/scheduleInitialScrollAfterLayout.test.ts
+++ b/__tests__/core/scheduleInitialScrollAfterLayout.test.ts
@@ -1,0 +1,52 @@
+import { Platform } from "react-native";
+
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { scheduleInitialScrollAfterLayout } from "../../src/core/scheduleInitialScrollAfterLayout";
+import { createMockState } from "../__mocks__/createMockState";
+
+describe("scheduleInitialScrollAfterLayout", () => {
+    const originalPlatform = Platform.OS;
+    const originalRequestAnimationFrame = globalThis.requestAnimationFrame;
+    const animationFrames: FrameRequestCallback[] = [];
+
+    beforeEach(() => {
+        Platform.OS = "android";
+        animationFrames.length = 0;
+        globalThis.requestAnimationFrame = ((callback: FrameRequestCallback) => {
+            animationFrames.push(callback);
+            return animationFrames.length;
+        }) as typeof requestAnimationFrame;
+    });
+
+    afterEach(() => {
+        Platform.OS = originalPlatform;
+        globalThis.requestAnimationFrame = originalRequestAnimationFrame;
+    });
+
+    it("reapplies the resolved horizontal offset on the frame after layout", () => {
+        const scrollCalls: Array<{ animated: boolean; x: number; y: number }> = [];
+        const state = createMockState({
+            props: {
+                data: Array.from({ length: 20 }, (_, index) => ({ id: index })),
+                getFixedItemSize: () => 360,
+                horizontal: true,
+            },
+            refScroller: {
+                current: {
+                    scrollTo: (params: { animated: boolean; x: number; y: number }) => scrollCalls.push(params),
+                } as any,
+            },
+            scrollLength: 360,
+        });
+
+        const frame = scheduleInitialScrollAfterLayout(state, { index: 9, viewOffset: 0 }, 3240);
+
+        expect(frame).toBe(1);
+        expect(scrollCalls).toHaveLength(0);
+
+        animationFrames[0](0);
+
+        expect(scrollCalls).toEqual([{ animated: false, x: 3240, y: 0 }]);
+        expect(state.scroll).toBe(3240);
+    });
+});

--- a/src/components/LegendList.tsx
+++ b/src/components/LegendList.tsx
@@ -32,6 +32,7 @@ import { finishScrollTo } from "@/core/finishScrollTo";
 import { handleLayout } from "@/core/handleLayout";
 import { onScroll } from "@/core/onScroll";
 import { ScrollAdjustHandler } from "@/core/ScrollAdjustHandler";
+import { scheduleInitialScrollAfterLayout } from "@/core/scheduleInitialScrollAfterLayout";
 import { scrollTo } from "@/core/scrollTo";
 import { scrollToIndex } from "@/core/scrollToIndex";
 import { updateItemPositions } from "@/core/updateItemPositions";
@@ -41,7 +42,7 @@ import { setupViewability } from "@/core/viewability";
 import { useCombinedRef } from "@/hooks/useCombinedRef";
 import { useInit } from "@/hooks/useInit";
 import { useOnLayoutSync } from "@/hooks/useOnLayoutSync";
-import { peek$, StateProvider, set$, useStateContext } from "@/state/state";
+import { peek$, StateProvider, set$, useSelector$, useStateContext } from "@/state/state";
 import type {
     InternalState,
     LegendListProps,
@@ -167,6 +168,7 @@ const LegendListInner = typedForwardRef(function LegendListInner<T>(
             : undefined;
 
     const [canRender, setCanRender] = React.useState(!IsNewArchitecture);
+    const containersDidLayout = useSelector$("containersDidLayout", Boolean);
 
     const contentContainerStyle = { ...StyleSheet.flatten(contentContainerStyleProp) };
     const style = { ...StyleSheet.flatten(styleProp) };
@@ -437,6 +439,21 @@ const LegendListInner = typedForwardRef(function LegendListInner<T>(
     const onLayoutChange = useCallback((layout: LayoutRectangle) => {
         handleLayout(ctx, state, layout, setCanRender);
     }, []);
+
+    useEffect(() => {
+        if (
+            !containersDidLayout ||
+            !IsNewArchitecture ||
+            Platform.OS !== "android" ||
+            initialScroll?.index === undefined
+        ) {
+            return;
+        }
+
+        const frame = scheduleInitialScrollAfterLayout(state, initialScroll, initialContentOffset);
+
+        return () => cancelAnimationFrame(frame);
+    }, [containersDidLayout]);
 
     const { onLayout } = useOnLayoutSync({
         onLayoutChange,

--- a/src/core/scheduleInitialScrollAfterLayout.ts
+++ b/src/core/scheduleInitialScrollAfterLayout.ts
@@ -1,0 +1,18 @@
+import { scrollTo } from "@/core/scrollTo";
+import type { InternalState, ScrollIndexWithOffset } from "@/types";
+
+export function scheduleInitialScrollAfterLayout(
+    state: InternalState,
+    initialScroll: ScrollIndexWithOffset,
+    initialContentOffset: number,
+) {
+    return requestAnimationFrame(() => {
+        scrollTo(state, {
+            ...initialScroll,
+            animated: false,
+            isInitialScroll: true,
+            offset: initialContentOffset,
+            viewPosition: initialScroll.index === state.props.data.length - 1 ? 1 : 0,
+        });
+    });
+}


### PR DESCRIPTION
Fixes #516.

## Summary

- wait for the initial recycled containers to finish layout on Android Fabric
- reapply the resolved `initialScrollIndex` offset on the next animation frame
- use the existing `scrollTo` path so native and internal scroll state advance together
- add a regression test for a horizontal fixed-size list starting at index 9

Android can intermittently drop the mount-time native `contentOffset` while content materializes. LegendList then considers the requested index visible internally while the native ScrollView remains at offset 0, leaving every recycled target container outside the viewport.

The correction is limited to Android New Architecture lists with a non-zero/defined `initialScrollIndex`. It runs once when the existing `containersDidLayout` signal becomes true.

## Reproduction

https://github.com/dukjjang/legend-list-initial-scroll-repro

Representative unpatched v2.0.19 failure:

- target index: 18
- native offset: 0
- internal scroll: 7406
- target cell x: -7405.7
- result: blank list viewport

Results on an Android API 36 emulator:

- v2.0.19 unpatched: failure reproduced intermittently
- v3.3.3 unpatched: 100/100 successful mounts
- patched `2.x`: 100/100 successful mounts

v3 already includes an Android bootstrap corrective-scroll path. This PR brings the same lifecycle guarantee to the maintained `2.x` implementation without changing its virtualization model.

## Validation

- `bun test`: 1,005 passed, 0 failed
- `bun run tsc`: passed
- `bun run build`: passed
- Biome check for all three changed files: passed
- reproduction app `npm run lint`: passed
- reproduction app `npx tsc --noEmit`: passed
- reproduction app `npm test -- --runInBand`: passed

`bun run lint` on the full `2.x` branch currently reports four pre-existing errors and 48 warnings in untouched test files. No lint diagnostics are reported for this PR's changed files.
