### PR TITLE
fix: cancel scheduled work without rebinding the global timer receiver

### DIFF
--- a/__tests__/core/ScheduledWork.test.ts
+++ b/__tests__/core/ScheduledWork.test.ts
@@ -96,6 +96,37 @@ describe("ScheduledWork", () => {
         expect(scheduledWork.has("platformScrollCompletion")).toBe(false);
     });
 
+    it("cancels native work without rebinding the global timer receiver", () => {
+        // Browsers reject `clearTimeout` / `cancelAnimationFrame` when the receiver is not the
+        // global object, so cancel() must not invoke the stored canceller as a property of its
+        // own bookkeeping tuple. Chrome reports that as "TypeError: Illegal invocation".
+        const receivers: unknown[] = [];
+        const assertGlobalReceiver = function (this: unknown) {
+            if (this !== undefined && this !== globalThis) {
+                throw new TypeError("Illegal invocation");
+            }
+            receivers.push(this);
+        };
+        globalThis.clearTimeout = function (this: unknown, handle: number) {
+            assertGlobalReceiver.call(this);
+            timeouts.delete(handle);
+        } as typeof clearTimeout;
+        globalThis.cancelAnimationFrame = function (this: unknown, handle: number) {
+            assertGlobalReceiver.call(this);
+            frames.delete(handle);
+        } as typeof cancelAnimationFrame;
+
+        scheduledWork.timeout(() => {}, 10, "adaptiveRender");
+        scheduledWork.frame(() => {}, "mvcpRecalculate");
+
+        expect(() => scheduledWork.cancel("adaptiveRender")).not.toThrow();
+        expect(() => scheduledWork.cancel("mvcpRecalculate")).not.toThrow();
+
+        expect(receivers).toEqual([undefined, undefined]);
+        expect(timeouts.size).toBe(0);
+        expect(frames.size).toBe(0);
+    });
+
     it("cancels every kind of pending work on dispose", () => {
         const calls: string[] = [];
         scheduledWork.timeout(() => calls.push("anonymous timeout"), 10);

--- a/src/core/ScheduledWork.ts
+++ b/src/core/ScheduledWork.ts
@@ -53,7 +53,8 @@ export class ScheduledWork {
         const work = this.work.get(key);
         if (work) {
             this.work.delete(key);
-            work[1](work[0]);
+            const [handle, cancel] = work;
+            cancel(handle);
         }
     }
 


### PR DESCRIPTION
## Problem

`ScheduledWork.cancel` invokes the stored canceller as `work[1](work[0])`:

```ts
cancel(key: ScheduledWorkKey) {
    const work = this.work.get(key);
    if (work) {
        this.work.delete(key);
        work[1](work[0]);   // member call -> `this` is the tuple
    }
}
```

Because that is a member expression, the native `clearTimeout` / `cancelAnimationFrame` stored in the tuple runs with `this` bound to the `Work` array instead of the global object. Browsers reject a non-global receiver on those methods, so on web and in Electron this throws:

```
Uncaught TypeError: Illegal invocation
```

`dispose()` in the same class already destructures (`for (const [handle, cancel] of ...) cancel(handle)`), which is why only `cancel()` is affected.

## User-facing impact

Any programmatic scroll reaches `cancel()`. Mounting a list with `initialScrollAtEnd` or `initialScrollIndex` schedules `imperativeScrollReady`, then cancels it — along with `checkFinishedScrollFrame` and `platformScrollCompletion` — once the scroll settles. The first cancel throws, so on web/Electron every list open logs an uncaught `TypeError`.

Reported downstream after upgrading 3.3.3 → 3.3.4: opening a chat thread throws on every mount.

Introduced in 26822d6 ("refactor: centralize scheduled work lifecycle"), shipped in 3.3.4. React Native is unaffected — its timers are plain JS functions that ignore the receiver.

## Reproduction

In any browser or Electron renderer:

```js
const work = [setTimeout(() => {}, 1000), clearTimeout];
work[1](work[0]);   // TypeError: Illegal invocation
```

Verified in an Electron 43 renderer:

```
{"clearTimeout":"TypeError: Illegal invocation",
 "cancelAnimationFrame":"TypeError: Illegal invocation",
 "plainRef":"OK"}
```

In-app: render a web `LegendList` with `initialScrollAtEnd` and watch the console on mount.

## Fix

Destructure the tuple before calling, matching `dispose()`. One line, no behavior change beyond the receiver.

## Test

The existing `ScheduledWork` tests replace the globals with arrow functions, which are as receiver-agnostic as React Native's timers — that is why this slipped through. The added regression test installs stubs that reject a non-global `this` the way a browser does, so it fails with `TypeError: Illegal invocation` on `main` and passes with the fix.

Verified locally: `bun run lint`, `bun run tsc:src`, `bun test` (1554 pass / 0 fail), `bun run build`.

I did not find an existing issue for this, so there is nothing to link — happy to open one if you would prefer the tracking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)