### PR TITLE
fix: reveal a fresh dataset when the readiness reset is never rendered

### DIFF
--- a/__tests__/hooks/useFreshDataTransitionVisibility.test.tsx
+++ b/__tests__/hooks/useFreshDataTransitionVisibility.test.tsx
@@ -10,6 +10,10 @@ function VisibilityProbe({ readyToRender, transitionEpoch }: { readyToRender: bo
     return <Text>{isVisible ? "visible" : "hidden"}</Text>;
 }
 
+function visibility(renderer: TestRenderer.ReactTestRenderer) {
+    return renderer.root.findByType(Text).props.children;
+}
+
 describe("useFreshDataTransitionVisibility", () => {
     it("hides a fresh dataset until the readiness reset has been observed", () => {
         let renderer!: TestRenderer.ReactTestRenderer;
@@ -17,22 +21,61 @@ describe("useFreshDataTransitionVisibility", () => {
         act(() => {
             renderer = TestRenderer.create(<VisibilityProbe readyToRender transitionEpoch={0} />);
         });
-        expect(renderer.root.findByType(Text).props.children).toBe("visible");
-
-        act(() => {
-            renderer.update(<VisibilityProbe readyToRender transitionEpoch={1} />);
-        });
-        expect(renderer.root.findByType(Text).props.children).toBe("hidden");
+        expect(visibility(renderer)).toBe("visible");
 
         act(() => {
             renderer.update(<VisibilityProbe readyToRender={false} transitionEpoch={1} />);
         });
-        expect(renderer.root.findByType(Text).props.children).toBe("hidden");
+        expect(visibility(renderer)).toBe("hidden");
 
         act(() => {
             renderer.update(<VisibilityProbe readyToRender transitionEpoch={1} />);
         });
-        expect(renderer.root.findByType(Text).props.children).toBe("visible");
+        expect(visibility(renderer)).toBe("visible");
+
+        act(() => {
+            renderer.unmount();
+        });
+    });
+
+    it("reveals a fresh dataset even when the readiness reset is never rendered", () => {
+        // The reset of readyToRender and the layout that restores it can both land in the same
+        // layout-effect pass, so the not-ready state never reaches a render. Waiting for it left
+        // the content hidden permanently with the list fully measured behind it.
+        let renderer!: TestRenderer.ReactTestRenderer;
+
+        act(() => {
+            renderer = TestRenderer.create(<VisibilityProbe readyToRender transitionEpoch={0} />);
+        });
+        expect(visibility(renderer)).toBe("visible");
+
+        act(() => {
+            renderer.update(<VisibilityProbe readyToRender transitionEpoch={1} />);
+        });
+        expect(visibility(renderer)).toBe("visible");
+
+        act(() => {
+            renderer.update(<VisibilityProbe readyToRender transitionEpoch={2} />);
+        });
+        expect(visibility(renderer)).toBe("visible");
+
+        act(() => {
+            renderer.unmount();
+        });
+    });
+
+    it("stays hidden while the list is not ready", () => {
+        let renderer!: TestRenderer.ReactTestRenderer;
+
+        act(() => {
+            renderer = TestRenderer.create(<VisibilityProbe readyToRender={false} transitionEpoch={0} />);
+        });
+        expect(visibility(renderer)).toBe("hidden");
+
+        act(() => {
+            renderer.update(<VisibilityProbe readyToRender={false} transitionEpoch={1} />);
+        });
+        expect(visibility(renderer)).toBe("hidden");
 
         act(() => {
             renderer.unmount();

--- a/src/hooks/useFreshDataTransitionVisibility.ts
+++ b/src/hooks/useFreshDataTransitionVisibility.ts
@@ -1,14 +1,16 @@
-import { useLayoutEffect, useRef } from "react";
+import { useLayoutEffect, useState } from "react";
 
 export function useFreshDataTransitionVisibility(readyToRender: boolean, transitionEpoch: number) {
-    const completedTransitionEpoch = useRef(transitionEpoch);
-    const isTransitionPending = completedTransitionEpoch.current !== transitionEpoch;
+    const [completedTransitionEpoch, setCompletedTransitionEpoch] = useState(transitionEpoch);
+    const isTransitionPending = completedTransitionEpoch !== transitionEpoch;
 
+    // Completing in an effect rather than on an observed `readyToRender === false` render keeps
+    // the pending flag from outliving the transition. The readiness reset and the layout that
+    // restores it can land in the same layout-effect pass, in which case this never renders in
+    // the not-ready state and a flag that waited for it would stay pending forever.
     useLayoutEffect(() => {
-        if (!readyToRender) {
-            completedTransitionEpoch.current = transitionEpoch;
-        }
-    }, [readyToRender, transitionEpoch]);
+        setCompletedTransitionEpoch(transitionEpoch);
+    }, [transitionEpoch]);
 
     return readyToRender && !isTransitionPending;
 }


### PR DESCRIPTION
## Problem

Changing `dataKey` can leave the list permanently invisible. The content is fully rendered, measured and scrollable — `ContainersInner` just keeps painting it at `opacity: 0`.

`useFreshDataTransitionVisibility` clears its pending flag only from a layout effect that requires a render where `readyToRender === false`:

```ts
const completedTransitionEpoch = useRef(transitionEpoch);
const isTransitionPending = completedTransitionEpoch.current !== transitionEpoch;

useLayoutEffect(() => {
    if (!readyToRender) {
        completedTransitionEpoch.current = transitionEpoch;
    }
}, [readyToRender, transitionEpoch]);
```

That render is not guaranteed. On a `dataKey` change the layout effect in `updateProps` calls `resetInitialRenderState` (which does `set$(ctx, "readyToRender", false)`) and then `handleInitialScrollDataChange`, which reaches `setDidLayout` → `setInitialRenderState` and sets it straight back to `true` — all in the same layout-effect pass. The two signal writes coalesce, `ContainersInner` only ever re-renders in the ready state, and the completed epoch stays one behind the transition epoch forever.

Nothing recovers it. `readyToRender` never drops again, so the effect never fires with the condition it needs.

## Evidence

Captured from the running app (React fiber walk to the list context) while the viewport was blank:

```
readyToRender: true          didContainersLayout: true
didFinishInitialScroll: true dataLen: 100   totalSize: 5915
freshDataTransitionEpoch: 2  completedTransitionEpoch.current: 1
```

The containers wrapper had `opacity: 0` with a correct `height: 5875px` and 35 measured rows inside it. Forcing a resize did not recover it, confirming this is not a missing layout event.

## Repro

Any consumer that swaps `dataKey` while the list stays ready. Ours is a chat thread that clears its messages and refetches centered on a search hit: same list instance, `dataKey` goes `conv:1` → `conv:2`, and the thread is blank from then on. Using `key` to remount instead works, because a fresh mount seeds `completedTransitionEpoch` from the current epoch.

## Fix

Track the completed epoch in state and complete it from an effect keyed on the epoch alone, so a transition always resolves:

```ts
const [completedTransitionEpoch, setCompletedTransitionEpoch] = useState(transitionEpoch);
const isTransitionPending = completedTransitionEpoch !== transitionEpoch;

useLayoutEffect(() => {
    setCompletedTransitionEpoch(transitionEpoch);
}, [transitionEpoch]);
```

Behavior is otherwise unchanged:

- While the list reports not ready, `readyToRender &&` still hides it — that is what covers the actual reset window.
- When readiness does drop and recover across renders, the sequence is the same as before.
- The reveal is a `setState` from a layout effect, so it flushes before paint, and `ContainersInner`'s layout effect runs before the parent's — the revealed frame is the one where the parent has already re-run `calculateItemsInView`. No stale frame is painted.
- `setState` with an unchanged value bails out, so there is no extra render in the steady state.

## Tests

The existing test asserted the buggy path implicitly: it drove the epoch bump with `readyToRender` held true, expected `hidden`, and only expected `visible` after a manual `readyToRender={false}` round trip. It now covers the round trip explicitly, plus two new cases — a transition that never renders the not-ready state (fails on `main` with the content stuck hidden), and staying hidden while the list is not ready.

Verified: `bun run lint`, `bun run tsc:src`, `bun test` (1555 pass / 0 fail), `bun run build`.

Related: #518 (separate 3.3.4 regression, independent of this one).

🤖 Generated with [Claude Code](https://claude.com/claude-code)