### PR TITLE
fix: follow content growth from first item measurements at the end

### DIFF
--- a/__tests__/core/updateItemSize.test.ts
+++ b/__tests__/core/updateItemSize.test.ts
@@ -271,6 +271,26 @@ describe("item size update functions", () => {
             doMaintainScrollAtEndSpy.mockRestore();
         });
 
+        it("anchors on a first measurement, which has no previously known size", () => {
+            // Rows added by a prepend are measured for the first time, so requiring a previously
+            // known size made maintainScrollAtEnd blind to the content they add and left the list
+            // parked short of its end.
+            const doMaintainScrollAtEndSpy = spyOn(
+                doMaintainScrollAtEndModule,
+                "doMaintainScrollAtEnd",
+            ).mockReturnValue(true);
+            mockState.props.maintainScrollAtEnd = {
+                animated: true,
+                on: { itemLayout: true },
+            };
+            expect(mockState.sizesKnown.has("item_0")).toBe(false);
+
+            updateItemAndFlush(mockCtx, "item_0", { height: 150, width: 400 });
+
+            expect(doMaintainScrollAtEndSpy).toHaveBeenCalledWith(mockCtx);
+            doMaintainScrollAtEndSpy.mockRestore();
+        });
+
         it("skips item-layout anchoring when on excludes it", () => {
             const doMaintainScrollAtEndSpy = spyOn(
                 doMaintainScrollAtEndModule,

--- a/src/core/updateItemSizes.ts
+++ b/src/core/updateItemSizes.ts
@@ -202,8 +202,10 @@ function applyItemSize(
             needsRecalculate = true;
         }
 
-        // Check if we should maintain scroll at end
-        if (prevSizeKnown !== undefined && Math.abs(prevSizeKnown - size) > 5) {
+        // Check if we should maintain scroll at end. A first measurement counts too: rows
+        // inserted by a prepend have no previously known size, so requiring one left their
+        // growth unfollowed and parked the list short of its end.
+        if (prevSizeKnown === undefined || Math.abs(prevSizeKnown - size) > 5) {
             shouldMaintainScrollAtEnd = true;
         }
 


### PR DESCRIPTION
## Problem

A list pinned to its end drifts short after a prepend, and never recovers.

`updateItemSizes` asks for a re-pin from an item layout only when the row already had a known size that moved more than 5px:

```ts
// Check if we should maintain scroll at end
if (prevSizeKnown !== undefined && Math.abs(prevSizeKnown - size) > 5) {
    shouldMaintainScrollAtEnd = true;
}
```

Rows measured for the **first** time take the `undefined` branch, so they never request one and `maintainScrollAtEnd.onItemLayout` cannot fire for them.

Prepending is entirely first measurements. The sequence:

1. Data changes → `onDataChange` re-pins against the content size at that instant.
2. The newly inserted rows measure for the first time and grow the content underneath.
3. No re-pin follows that growth.
4. The residue ends up smaller than `maintainScrollAtEndThreshold`, so `isWithinMaintainScrollAtEndThreshold` and `isAtEnd` both read true and the list considers itself finished — parked a couple hundred pixels short of the last item.

Step 4 is what makes it stick: the list believes it is already at the end, so nothing later corrects it.

## Evidence

Instrumented `updateItemSizes` and `doMaintainScrollAtEnd` in a running web list and ran the failing flow:

```
measurements:   285 total  →  first=true: 285,  first=false: 0
maintain calls: 3         →  last was the onDataChange re-pin
after it:       ~25 further first measurements moved totalSize
                scroll frozen, no maintain call
final:          gap = +57px  (pinned baseline is -116px)
```

Every measurement in the flow is a first measurement, so the item-layout path is unreachable end to end.

With the condition flipped, the same flow:

```
maintain calls: 9
trailing measurements coalesce via pendingMaintainScrollAtEnd
final:          gap = -116px   (pinned)
```

## Fix

Treat a first measurement as maintain-worthy too. `doMaintainScrollAtEnd` still gates on `isWithinMaintainScrollAtEndThreshold` and `didContainersLayout`, so this only follows growth for a list already sitting at its end, and concurrent requests still coalesce through `pendingMaintainScrollAtEnd`.

## Test

Every existing test in `updateItemSize.test.ts` pre-seeds `sizesKnown`, so none covered a first measurement — which is why this path had no coverage. The added test asserts `doMaintainScrollAtEnd` is called when `sizesKnown` has no entry for the item; it fails on `main`.

Verified: `bun run lint`, `bun run tsc:src`, `bun test` (1554 pass / 0 fail), `bun run build`.

Related: #518, #519 (independent 3.3.x issues).

🤖 Generated with [Claude Code](https://claude.com/claude-code)