### PR TITLE
fix: compensate header size changes for MVCP on native

### DIFF
--- a/__tests__/core/contentMetrics.test.ts
+++ b/__tests__/core/contentMetrics.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, spyOn } from "bun:test";
 import { clampScrollOffset } from "../../src/core/clampScrollOffset";
+import { ScrollAdjustHandler } from "../../src/core/ScrollAdjustHandler";
 import { setContentInsetOverride, setFooterSize, setHeaderSize } from "../../src/core/updateContentMetrics";
 import { updateContentMetricsState } from "../../src/core/updateContentMetricsState";
 import { Platform } from "../../src/platform/Platform";
@@ -201,42 +202,87 @@ describe("updateContentMetrics", () => {
         expect(ctx.values.get("footerSize")).toBe(12);
     });
 
-    it("compensates web MVCP when a measured header changes above the viewport", () => {
-        const prevPlatform = Platform.OS;
-        Platform.OS = "web";
-        const requestAdjustSpy = spyOn(requestAdjustModule, "requestAdjust");
-        const ctx = createMockContext(
-            {
-                headerSize: 60,
-                readyToRender: true,
-                totalSize: 1000,
-            },
-            {
-                didContainersLayout: true,
-                didFinishInitialScroll: true,
-                props: {
-                    data: [1],
-                    maintainVisibleContentPosition: { data: false, size: true },
+    for (const platformOS of ["web", "ios", "android"] as const) {
+        it(`compensates MVCP on ${platformOS} when a measured header changes above the viewport`, () => {
+            const prevPlatform = Platform.OS;
+            Platform.OS = platformOS;
+            const requestAdjustSpy = spyOn(requestAdjustModule, "requestAdjust");
+            const ctx = createMockContext(
+                {
+                    headerSize: 60,
+                    readyToRender: true,
+                    totalSize: 1000,
                 },
-                scroll: 200,
-                scrollLength: 500,
-                totalSize: 1000,
-            },
-        );
+                {
+                    didContainersLayout: true,
+                    didFinishInitialScroll: true,
+                    props: {
+                        data: [1],
+                        maintainVisibleContentPosition: { data: false, size: true },
+                    },
+                    scroll: 200,
+                    scrollLength: 500,
+                    totalSize: 1000,
+                },
+            );
 
-        try {
-            setHeaderSize(ctx, 60);
-            expect(requestAdjustSpy).not.toHaveBeenCalled();
+            try {
+                setHeaderSize(ctx, 60);
+                expect(requestAdjustSpy).not.toHaveBeenCalled();
 
-            requestAdjustSpy.mockClear();
-            setHeaderSize(ctx, 120);
+                requestAdjustSpy.mockClear();
+                setHeaderSize(ctx, 120);
 
-            expect(requestAdjustSpy).toHaveBeenCalledWith(ctx, 60);
-        } finally {
-            requestAdjustSpy.mockRestore();
-            Platform.OS = prevPlatform;
-        }
-    });
+                expect(requestAdjustSpy).toHaveBeenCalledWith(ctx, 60);
+
+                requestAdjustSpy.mockClear();
+                setHeaderSize(ctx, 60);
+
+                expect(requestAdjustSpy).toHaveBeenCalledWith(ctx, -60);
+            } finally {
+                requestAdjustSpy.mockRestore();
+                Platform.OS = prevPlatform;
+            }
+        });
+
+        it(`settles the scroll position on ${platformOS} when a measured header grows above the viewport`, () => {
+            const prevPlatform = Platform.OS;
+            Platform.OS = platformOS;
+            const ctx = createMockContext(
+                {
+                    headerSize: 60,
+                    readyToRender: true,
+                    totalSize: 1000,
+                },
+                {
+                    didContainersLayout: true,
+                    didFinishInitialScroll: true,
+                    props: {
+                        data: [1],
+                        maintainVisibleContentPosition: { data: false, size: true },
+                    },
+                    scroll: 200,
+                    scrollLength: 500,
+                    totalSize: 1000,
+                },
+            );
+            // Drive the real adjust handler so the assertion is about the resulting scroll
+            // position the user sees, not just that an adjustment was requested.
+            ctx.state.scrollAdjustHandler = new ScrollAdjustHandler(ctx);
+
+            try {
+                setHeaderSize(ctx, 60);
+                setHeaderSize(ctx, 120);
+
+                // The header grew by 60 above the viewport, so the same content stays put.
+                expect(ctx.state.scroll).toBe(260);
+                expect(ctx.values.get("scrollAdjust")).toBe(60);
+            } finally {
+                ctx.state.scheduledWork.dispose();
+                Platform.OS = prevPlatform;
+            }
+        });
+    }
 
     it("does not compensate the initial web MVCP header measurement", () => {
         const prevPlatform = Platform.OS;
@@ -339,37 +385,39 @@ describe("updateContentMetrics", () => {
         }
     });
 
-    it("does not compensate web MVCP header changes while the header is visible", () => {
-        const prevPlatform = Platform.OS;
-        Platform.OS = "web";
-        const requestAdjustSpy = spyOn(requestAdjustModule, "requestAdjust");
-        const ctx = createMockContext(
-            {
-                headerSize: 60,
-                readyToRender: true,
-                totalSize: 1000,
-            },
-            {
-                didContainersLayout: true,
-                didFinishInitialScroll: true,
-                didMeasureHeader: true,
-                props: {
-                    data: [1],
-                    maintainVisibleContentPosition: { data: false, size: true },
+    for (const platformOS of ["web", "ios", "android"] as const) {
+        it(`does not compensate MVCP header changes on ${platformOS} while the header is visible`, () => {
+            const prevPlatform = Platform.OS;
+            Platform.OS = platformOS;
+            const requestAdjustSpy = spyOn(requestAdjustModule, "requestAdjust");
+            const ctx = createMockContext(
+                {
+                    headerSize: 60,
+                    readyToRender: true,
+                    totalSize: 1000,
                 },
-                scroll: 20,
-                scrollLength: 500,
-                totalSize: 1000,
-            },
-        );
+                {
+                    didContainersLayout: true,
+                    didFinishInitialScroll: true,
+                    didMeasureHeader: true,
+                    props: {
+                        data: [1],
+                        maintainVisibleContentPosition: { data: false, size: true },
+                    },
+                    scroll: 20,
+                    scrollLength: 500,
+                    totalSize: 1000,
+                },
+            );
 
-        try {
-            setHeaderSize(ctx, 120);
+            try {
+                setHeaderSize(ctx, 120);
 
-            expect(requestAdjustSpy).not.toHaveBeenCalled();
-        } finally {
-            requestAdjustSpy.mockRestore();
-            Platform.OS = prevPlatform;
-        }
-    });
+                expect(requestAdjustSpy).not.toHaveBeenCalled();
+            } finally {
+                requestAdjustSpy.mockRestore();
+                Platform.OS = prevPlatform;
+            }
+        });
+    }
 });

--- a/example/screens/fixtures/header-mvcp.tsx
+++ b/example/screens/fixtures/header-mvcp.tsx
@@ -1,0 +1,135 @@
+import { useRef, useState } from "react";
+import { Pressable, StyleSheet, Text, View } from "react-native";
+
+import { LegendList, type LegendListRef } from "@legendapp/list/react-native";
+
+const ROW_HEIGHT = 72;
+const INITIAL_HEADER_HEIGHT = 96;
+const ANCHOR_ROW_INDEX = 20;
+const DATA = Array.from({ length: 80 }, (_, index) => ({
+    id: String(index),
+    title: `Row ${index}`,
+}));
+
+type RowItem = (typeof DATA)[number];
+
+function Header({ height }: { height: number }) {
+    return (
+        <View style={[styles.header, { height }]}>
+            <Text style={styles.headerTitle}>Measured ListHeaderComponent</Text>
+            <Text style={styles.headerSubtitle}>height: {height}</Text>
+        </View>
+    );
+}
+
+export default function HeaderMvcpFixture() {
+    const listRef = useRef<LegendListRef>(null);
+    const [headerHeight, setHeaderHeight] = useState(INITIAL_HEADER_HEIGHT);
+    const [scrollOffset, setScrollOffset] = useState(0);
+
+    return (
+        <View style={styles.container}>
+            <LegendList<RowItem>
+                data={DATA}
+                estimatedItemSize={ROW_HEIGHT}
+                initialScrollIndex={ANCHOR_ROW_INDEX}
+                keyExtractor={(item) => item.id}
+                ListHeaderComponent={<Header height={headerHeight} />}
+                maintainVisibleContentPosition={{ data: false, size: true }}
+                onScroll={(event) => setScrollOffset(event.nativeEvent.contentOffset.y)}
+                recycleItems
+                ref={listRef}
+                renderItem={({ item }) => (
+                    <View style={styles.row}>
+                        <Text style={styles.rowText}>{item.title}</Text>
+                    </View>
+                )}
+                style={styles.list}
+            />
+
+            <View style={styles.controls}>
+                <Text style={styles.readout}>scrollOffset: {Math.round(scrollOffset)}</Text>
+                <View style={styles.buttonRow}>
+                    <Pressable onPress={() => setHeaderHeight((value) => value + 80)} style={styles.button}>
+                        <Text style={styles.buttonText}>Grow header</Text>
+                    </Pressable>
+                    <Pressable
+                        onPress={() => setHeaderHeight((value) => Math.max(24, value - 80))}
+                        style={styles.button}
+                    >
+                        <Text style={styles.buttonText}>Shrink header</Text>
+                    </Pressable>
+                    <Pressable
+                        onPress={() => listRef.current?.scrollToOffset({ animated: false, offset: 0 })}
+                        style={styles.button}
+                    >
+                        <Text style={styles.buttonText}>Show header</Text>
+                    </Pressable>
+                </View>
+            </View>
+        </View>
+    );
+}
+
+const styles = StyleSheet.create({
+    button: {
+        backgroundColor: "#1e3a8a",
+        borderRadius: 6,
+        paddingHorizontal: 12,
+        paddingVertical: 8,
+    },
+    buttonRow: {
+        flexDirection: "row",
+        gap: 8,
+    },
+    buttonText: {
+        color: "#ffffff",
+        fontSize: 13,
+    },
+    container: {
+        backgroundColor: "#ffffff",
+        flex: 1,
+    },
+    controls: {
+        backgroundColor: "#f8fafc",
+        borderTopColor: "#cbd5e1",
+        borderTopWidth: 1,
+        gap: 8,
+        padding: 12,
+    },
+    header: {
+        backgroundColor: "#dbeafe",
+        borderBottomColor: "#bfdbfe",
+        borderBottomWidth: 1,
+        justifyContent: "center",
+        paddingHorizontal: 20,
+    },
+    headerSubtitle: {
+        color: "#1e3a8a",
+        fontSize: 12,
+    },
+    headerTitle: {
+        color: "#1e3a8a",
+        fontSize: 14,
+        fontWeight: "600",
+    },
+    list: {
+        flex: 1,
+    },
+    readout: {
+        color: "#0f172a",
+        fontSize: 13,
+        fontVariant: ["tabular-nums"],
+    },
+    row: {
+        borderBottomColor: "#dbe3ef",
+        borderBottomWidth: 1,
+        height: ROW_HEIGHT,
+        justifyContent: "center",
+        paddingHorizontal: 20,
+    },
+    rowText: {
+        color: "#0f172a",
+        fontSize: 15,
+    },
+});

--- a/example/screens/routes.tsx
+++ b/example/screens/routes.tsx
@@ -54,6 +54,7 @@ import CountriesWithHeadersFixedFixture from "~/screens/fixtures/countries-with-
 import CountriesWithHeadersStickyFixture from "~/screens/fixtures/countries-with-headers-sticky";
 import ExtraDataFixture from "~/screens/fixtures/extra-data";
 import FilterElementsFixture from "~/screens/fixtures/filter-elements";
+import HeaderMvcpFixture from "~/screens/fixtures/header-mvcp";
 import HorizontalAlignItemsFixture from "~/screens/fixtures/horizontal-align-items";
 import HorizontalCrossAxisFixture from "~/screens/fixtures/horizontal-cross-axis";
 import InitialScrollAtEndEmptyFixture from "~/screens/fixtures/initial-scroll-at-end-empty";
@@ -258,6 +259,15 @@ export const FIXTURE_ROUTES: FixtureRouteDefinition[] = [
         kind: "fixture",
         slug: "mvcp-test",
         title: "MVCP Test",
+    },
+    {
+        component: HeaderMvcpFixture,
+        description: "Grows and shrinks a measured header while it is above the viewport.",
+        groupKey: "scroll",
+        groupTitle: "Scroll & Position",
+        kind: "fixture",
+        slug: "header-mvcp",
+        title: "Header MVCP",
     },
     {
         component: AlwaysRenderFixture,

--- a/src/core/updateContentMetrics.ts
+++ b/src/core/updateContentMetrics.ts
@@ -1,4 +1,3 @@
-import { Platform } from "@/platform/Platform";
 import { peek$, type StateContext, set$ } from "@/state/state";
 import type { Insets } from "@/types.base";
 import { requestAdjust } from "@/utils/requestAdjust";
@@ -25,7 +24,6 @@ function shouldAdjustForHeaderSizeChange(ctx: StateContext, previousHeaderSize: 
     const previousHeaderEnd = (leadingPadding || 0) + previousHeaderSize;
 
     return (
-        Platform.OS === "web" &&
         props.maintainVisibleContentPosition.size &&
         didContainersLayout &&
         didFinishInitialScroll &&


### PR DESCRIPTION
Fixes #515.

## User-facing impact

With `maintainVisibleContentPosition`, a `ListHeaderComponent` that changes size while the user is scrolled below it was compensated on **web only**. On iOS and Android the viewport jumped by the header's size delta. The reporter hit this in a chat-style thread that swaps a small "load previous" spinner for a full post card on the last upward page.

## Root cause

`shouldAdjustForHeaderSizeChange` in `src/core/updateContentMetrics.ts` opened with `Platform.OS === "web" &&`, so `setHeaderSize` never reached `requestAdjust` on native.

Nothing else covers this on native. MVCP anchors on `state.positions[]` (`prepareMVCP`, `src/core/mvcp.ts`), and those positions exclude `headerSize` — the header is folded in separately as `topPad` in `calculateItemsInView.ts` and via `getContentSize`. A header-only size change therefore produces no item position diff for MVCP to act on.

## Why removing the gate is safe

The gate came from `f46e6dd` ("fix: preserve web MVCP for changing headers #468"), whose message says it tracks header baselines *"on web"*. #468 was reported and tested on web only, so the web scoping looks like scope of testing rather than a deliberate native exclusion.

Removing the clause routes native onto the same `requestAdjust` path already used for item size changes, which is native-aware in its own right (`src/utils/requestAdjust.ts`): the Android old-architecture `doScrollTo` workaround and the `ignoreScrollFromMVCP` threshold window are native-only branches.

**On double-compensation against native RN MVCP:** the RN `maintainVisibleContentPosition` prop is passed to the ScrollView with `minIndexForVisible: 0` (`src/components/ListComponent.tsx`), and the first content subview is the `ScrollAdjust` sentinel — a 0x0 absolutely positioned `View` at `top: scrollAdjust + 10_000_000` (`src/components/ScrollAdjust.native.tsx`). Because that sentinel's origin always exceeds the content offset, RN's "first visible view" search picks it every time, so native MVCP only ever tracks the `scrollAdjust` signal. Routing the header delta through `requestAdjust` is the single intended path, not a second one. The measured behavior below confirms it: the offset moves by exactly the header delta, not twice.

The remaining guards are untouched, so the initial header measurement and changes made while the header is still visible stay uncompensated on every platform.

## Verification

`bun test` 1590 pass / 0 fail, `bun run lint`, `bun run tsc:src`, `bun run tsc:example`, `bun run build` all clean.

**Unit** (`__tests__/core/contentMetrics.test.ts`): the header compensation test and the header-still-visible test are now parameterised over `web` / `ios` / `android`, plus a new test per platform that drives the real `ScrollAdjustHandler` (no `requestAdjust` spy) and asserts the resulting settle position, not just that an adjustment was requested.

Counterfactual — with the source change reverted and only the tests applied, the 4 native cases fail:

```
(fail) compensates MVCP on ios when a measured header changes above the viewport
(fail) settles the scroll position on ios when a measured header grows above the viewport
(fail) compensates MVCP on android when a measured header changes above the viewport
(fail) settles the scroll position on android when a measured header grows above the viewport
 17 pass, 4 fail
```

Web stayed green throughout. With the fix restored: 21 pass / 0 fail in that file.

**iOS simulator** (iPhone 17 Pro, iOS 26.3, New Architecture, `example` fixtures) using the new `header-mvcp` fixture, starting at `initialScrollIndex={20}` with `scrollOffset: 1536` and Row 20 at the top of the viewport:

| Action | Before | After |
| --- | --- | --- |
| Grow header 96 → 176 | offset stays 1536, content jumps — **Row 19 takes Row 20's place** | offset 1536 → **1616**, Row 20 stays put |
| Shrink header 176 → 96 | — | offset 1616 → **1536**, Row 20 stays put |
| Grow while scrolled to top (header visible) | — | offset stays **0**, header grows in place (guard still holds) |
| Scroll back to top after several grow/shrink cycles | — | offset **0**, header renders at its current height, no accumulated drift |

The before column is the same build with only the `Platform.OS === "web" &&` clause restored, verified back-to-back on the same simulator.

Android was not exercised on a device; it is covered by the unit tests only.

## Fixture

`example/screens/fixtures/header-mvcp.tsx` mirrors the existing `example-web/src/fixtures/HeaderMvcpExample.tsx` added for #468, so the same scenario can be checked manually on native. It shows the live `scrollOffset` so the settle position is directly observable.

## Out of scope

The issue also mentions a **one-frame flash** that remains after this fix — the grown header paints at the old offset for a frame before the adjustment lands, because native applies it after the layout commit while web applies it synchronously. That is a separate problem (it needs the adjustment to be applied synchronously with the layout commit, or an `estimatedHeaderSize` seed) and is deliberately left as follow-up. This PR only fixes the settle position.
