### PR TITLE
fix: attach the rebuilt sticky transform node, and stop flooring averaged size estimates

### DIFF
--- a/__tests__/components/PositionView.native.test.tsx
+++ b/__tests__/components/PositionView.native.test.tsx
@@ -5,7 +5,7 @@ import * as React from "react";
 import { describe, expect, it, mock } from "bun:test";
 import { PositionView, PositionViewSticky } from "../../src/components/PositionView.native";
 import { updateItemSizes } from "../../src/core/updateItemSizes";
-import { type StateContext, StateProvider, useStateContext } from "../../src/state/state";
+import { type StateContext, StateProvider, set$, useStateContext } from "../../src/state/state";
 import { createMockState } from "../__mocks__/createMockState";
 import { setLayoutValue } from "../helpers/layoutArrays";
 import { act, render } from "../helpers/testingLibrary";
@@ -127,6 +127,58 @@ function ReplacementMeasurementHarness() {
     );
 }
 
+function MountProbe({ onMount }: { onMount: () => void }) {
+    React.useEffect(() => {
+        onMount();
+    }, [onMount]);
+
+    return null;
+}
+
+function StickyRemountHarness({
+    animatedScrollY,
+    onMount,
+}: {
+    animatedScrollY: { interpolate: (config: any) => any };
+    onMount: () => void;
+}) {
+    const ctx = useStateContext();
+    const didSetupRef = React.useRef(false);
+    currentCtx = ctx;
+
+    if (!didSetupRef.current) {
+        ctx.state = createMockState({
+            positions: [],
+            props: {
+                stickyHeaderIndicesArr: [1],
+            },
+        }) as any;
+        ctx.state.positions[1] = 100;
+        ctx.state.sizes.set("header-1", 120);
+        ctx.values.set("alignItemsAtEndPadding", 0);
+        ctx.values.set("containerItemIndex7", 1);
+        ctx.values.set("containerItemKey7", "header-1");
+        ctx.values.set("containerPosition7", 100);
+        ctx.values.set("headerSize", 0);
+        ctx.values.set("stylePaddingTop", 0);
+        ctx.values.set("totalSize", 420);
+        didSetupRef.current = true;
+    }
+
+    return (
+        <PositionViewSticky
+            animatedScrollY={animatedScrollY as any}
+            horizontal={false}
+            id={7}
+            onLayout={() => {}}
+            refView={{ current: null }}
+            style={{}}
+        >
+            <MountProbe onMount={onMount} />
+        </PositionViewSticky>
+    );
+}
+
 describe("PositionView.native", () => {
     it("pushes a tall sticky header out when the next sticky header arrives", () => {
         const interpolate = mock((config: any) => config);
@@ -225,5 +277,48 @@ describe("PositionView.native", () => {
         } finally {
             globalThis.requestAnimationFrame = originalRaf;
         }
+    });
+    it("rebuilds the sticky transform node when the container position changes", () => {
+        const interpolate = mock((config: any) => config);
+        const onMount = mock(() => {});
+        currentCtx = undefined;
+
+        const { toJSON, unmount } = render(
+            <StateProvider>
+                <StickyRemountHarness animatedScrollY={{ interpolate }} onMount={onMount} />
+            </StateProvider>,
+        );
+
+        expect(onMount).toHaveBeenCalledTimes(1);
+        expect(flattenStyle((toJSON() as any)?.props?.style)?.transform).toEqual([
+            {
+                translateY: {
+                    extrapolateLeft: "clamp",
+                    extrapolateRight: "extend",
+                    inputRange: [100, 5100],
+                    outputRange: [100, 5100],
+                },
+            },
+        ]);
+
+        act(() => {
+            set$(currentCtx!, "containerPosition7", 260);
+        });
+
+        expect(flattenStyle((toJSON() as any)?.props?.style)?.transform).toEqual([
+            {
+                translateY: {
+                    extrapolateLeft: "clamp",
+                    extrapolateRight: "extend",
+                    inputRange: [260, 5260],
+                    outputRange: [260, 5260],
+                },
+            },
+        ]);
+        // The interpolation node is recreated, so the view has to remount for Animated to
+        // attach the new node instead of keeping the one bound at the old position.
+        expect(onMount).toHaveBeenCalledTimes(2);
+
+        unmount();
     });
 });

--- a/__tests__/utils/getItemSize.test.ts
+++ b/__tests__/utils/getItemSize.test.ts
@@ -165,4 +165,22 @@ describe("getItemSize", () => {
 
         expect(result).toBe(0);
     });
+    it("rounds an averaged size to the nearest eighth instead of flooring it", () => {
+        mockState.averageSizes[""] = { avg: 80.1, num: 1 };
+
+        const result = callGetItemSize("item_0", 0, { id: 0 }, true);
+
+        expect(result).toBe(80.125);
+    });
+
+    it("does not accumulate a downward bias when summing averaged sizes", () => {
+        mockState.averageSizes[""] = { avg: 80.1, num: 1 };
+
+        let total = 0;
+        for (let index = 0; index < 1000; index++) {
+            total += callGetItemSize(`item_${index}`, index, { id: index }, true);
+        }
+
+        expect(Math.abs(total - 80.1 * 1000)).toBeLessThan(30);
+    });
 });

--- a/src/components/PositionView.native.tsx
+++ b/src/components/PositionView.native.tsx
@@ -162,8 +162,11 @@ const PositionViewSticky = typedMemo(function PositionViewSticky({
         );
     }, [stickyHeaderConfig?.backdropComponent]);
 
+    // The interpolation above is rebuilt whenever position changes, but Animated keeps the node it
+    // attached on mount, so the header would keep following the range of its previous position.
+    // Keying on position remounts the view and lets Animated attach the new node.
     return (
-        <Animated.View ref={refView} style={viewStyle} {...rest}>
+        <Animated.View key={`sticky-pos:${position}`} ref={refView} style={viewStyle} {...rest}>
             {renderStickyHeaderBackdrop}
             {children}
         </Animated.View>

--- a/src/utils/getItemSize.ts
+++ b/src/utils/getItemSize.ts
@@ -1,6 +1,6 @@
 import { setSize } from "@/core/setSize";
 import type { StateContext } from "@/state/state";
-import { roundSize } from "@/utils/helpers";
+import { roundEstimatedSize } from "@/utils/helpers";
 import { getId } from "./getId";
 
 export interface ResolvedItemSize {
@@ -92,7 +92,7 @@ export function getItemSize(
         // Use item type specific average if available
         const averageSizeForType = averageSizes[itemType]?.avg;
         if (averageSizeForType !== undefined) {
-            size = roundSize(averageSizeForType);
+            size = roundEstimatedSize(averageSizeForType);
         }
     }
 
@@ -105,7 +105,7 @@ export function getItemSize(
     if (size === undefined && useAverageSize && scrollingTo) {
         const averageSizeForType = scrollingTo.averageSizeSnapshot?.[itemType];
         if (averageSizeForType !== undefined) {
-            size = roundSize(averageSizeForType);
+            size = roundEstimatedSize(averageSizeForType);
         }
     }
 

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -25,6 +25,12 @@ export function roundSize(size: number) {
     return Math.floor(size * 8) / 8; // Round to nearest quater pixel to avoid accumulating rounding errors
 }
 
+// Estimates are summed across many items, so flooring would bias every estimate low and the
+// error would accumulate over the list. Round to the nearest eighth instead to keep it unbiased.
+export function roundEstimatedSize(size: number) {
+    return Math.round(size * 8) / 8;
+}
+
 export function isNullOrUndefined(value: unknown) {
     return value === null || value === undefined;
 }


### PR DESCRIPTION
# Why

Two independent bugs, both in size/position estimation.

**1. Sticky headers detach from their section after a data change** — addresses #445, which is still reproducing on 3.3.3 according to the last few reports in that thread.

`PositionViewSticky` builds its transform by interpolating `animatedScrollY` over an input/output range derived from the container's `position`. When `position` changes — which is exactly what happens on any data change that shifts a section — the memo produces a brand new interpolation node, but the `Animated.View` stays mounted and keeps the node it attached on mount. The header then keeps following the range computed for its *previous* position, so it paints at the wrong offset and looks detached from its section.

That also explains why every workaround in #445 is some variant of "put a `key` on the list": remounting is currently the only way to get Animated to pick up the new node.

**2. Averaged size estimates are biased low.**

`roundSize` floors to the nearest eighth of a pixel. That's the conservative choice for a size you actually measured, but `getItemSize` also uses it for *averaged* estimates, and those get summed across every unmeasured item. Flooring loses up to 1/8px per item in one direction only, so the error accumulates instead of cancelling out: with an average of 80.1, 1000 items estimate to 80,000 instead of 80,100 — 100px of content size that isn't there. The comment on `roundSize` already says "round to nearest … to avoid accumulating rounding errors", which is what the estimate path wants.

# How

- **`PositionView.native.tsx`** — key the sticky `Animated.View` on `position`, so a changed position remounts the view and Animated attaches the freshly built interpolation node. Scoped to the sticky branch only; `PositionViewState` and `PositionViewAnimated` apply position through style and are unaffected.
- **`helpers.ts` / `getItemSize.ts`** — add `roundEstimatedSize` (nearest eighth) and use it for the two averaged-estimate paths. `roundSize` keeps flooring for measured sizes, so `updateItemSizes` and `useContainerMeasurement` are untouched.

Two things worth flagging:

- Keying remounts the sticky item's subtree when its position changes. That's bounded — position changes on data/layout changes, not per scroll frame, since scrolling itself is handled by the transform — but if you'd rather not remount user content, the deeper fix is to keep the interpolation stable and drive the offset separately. Happy to rework it that way if you prefer.
- I left `integrations/reanimated.tsx` alone; it has its own sticky implementation and I can't verify it against the same repro.

# Test Plan

- `bun test` — **1586 pass, 0 fail** (1583 before, 3 added)
- `bunx biome check ./src ./__tests__` — clean
- `bun run tsc:src` — clean

New `PositionView.native` test asserts that when `containerPosition` changes, the interpolation node is rebuilt **and** the view remounts. On `main` it fails showing exactly the bug: the style already carries the new `inputRange`/`outputRange` while the view is never remounted, so Animated is still driving the old node.

```
Expected number of calls: 2
Received number of calls: 1
(fail) PositionView.native > rebuilds the sticky transform node when the container position changes
```

New `getItemSize` tests cover the rounding: an 80.1 average resolves to 80.125 instead of 80, and summing 1000 estimates stays within a few px of the true total instead of drifting 100px low.

Beyond the unit tests, both fixes have been running as a patch on 3.3.3 in an app that uses `SectionList` with `stickyHeaderIndices` over data that changes — which is how I hit #445 in the first place.
